### PR TITLE
Relationships Redux

### DIFF
--- a/Source/Stargate/Stargate.csproj
+++ b/Source/Stargate/Stargate.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Stargate\Saving\Dialog\Dialog_SavePreset.cs" />
     <Compile Include="Stargate\Saving\SaveThings.cs" />
     <Compile Include="Stargate\StargateBuffer.cs" />
+    <Compile Include="Stargate\StargateRelation.cs" />
     <Compile Include="Stargate\StargateThingDef.cs" />
     <Compile Include="Utilities\FindingThings.cs" />
   </ItemGroup>

--- a/Source/Stargate/Stargate.csproj
+++ b/Source/Stargate/Stargate.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Stargate\Building_OffWorldStargate.cs" />
     <Compile Include="Stargate\Building_Stargate.cs" />
     <Compile Include="Stargate\Building_TrandimensionalStargate.cs" />
+    <Compile Include="Stargate\GateTravelerImplant.cs" />
     <Compile Include="Stargate\ITab_StargateBuffer_Inventory.cs" />
     <Compile Include="Stargate\PlaceWorker_OnlyOneBuilding.cs" />
     <Compile Include="Stargate\PlaceWorker_OnlyOneStargate.cs" />

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -570,6 +570,11 @@ namespace BetterRimworlds.Stargate
             return new Tuple<int, List<Thing>>(originalTimelineTicks, inboundBuffer);
         }
 
+        private void cleanseHistoricalRecord(Pawn transmittedPawn)
+        {
+            StargateBuffer.ClearExistingWorldPawn(transmittedPawn);
+        }
+
         // @FIXME: Need to refactor this to a StargateBuffer.
         private void rebuildRelationships(Pawn transmittedPawn)
         {
@@ -693,6 +698,8 @@ namespace BetterRimworlds.Stargate
                     {
                         if (offworldEvent)
                         {
+                            // Cleanse the historical record for returning pawns.
+                            this.cleanseHistoricalRecord(pawn);
                         }
                         if (pawn.RaceProps.Humanlike)
                         {
@@ -859,6 +866,16 @@ namespace BetterRimworlds.Stargate
                         // Give them a brief psychic shock so that they will be given proper Melee Verbs and not act like a Visitor.
                         // Hediff shock = HediffMaker.MakeHediff(HediffDefOf.PsychicShock, pawn, null);
                         // pawn.health.AddHediff(shock, null, null);
+                        PawnComponentsUtility.AddAndRemoveDynamicComponents(pawn, true);
+
+                        // Find.CurrentMap.mapPawns.AllPawnsUnspawned.Remove(pawn);
+                        // Find.WorldPawns.AllPawnsDead.Remove(pawn);
+                        Pawn pawnToRemove = Find.WorldPawns.AllPawnsDead
+                            .FirstOrDefault(p => p.thingIDNumber == pawn.thingIDNumber);
+                        if (pawnToRemove != null)
+                        {
+                            Find.WorldPawns.RemovePawn(pawnToRemove);
+                        }
                     }
 
                     wasPlaced = GenPlace.TryPlaceThing(currentThing, this.Position + new IntVec3(0, 0, -2),

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -867,7 +867,7 @@ namespace BetterRimworlds.Stargate
                             if (thisPawn.RaceProps.Animal)
                             {
                                 #if RIMWORLD12
-                                thisPawn.training = new Pawn_TrainingTracker(thisPawn);
+                                // thisPawn.training = new Pawn_TrainingTracker(thisPawn);
                                 #else
                                 thisPawn.training.pawn = thisPawn;
                                 #endif

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -388,15 +388,19 @@ namespace BetterRimworlds.Stargate
 
             foreach (Thing foundThing in foundThings)
             {
-                // if (foundThing.Spawned && this.stargateBuffer.Count < 1000)
-                // {
                 if (!this.stargateBuffer.Any())
                 {
                     this.stargateSounds["Stargate Open"].PlayOneShotOnCamera();
                 }
 
                 this.stargateBuffer.TryAdd(foundThing);
-                // }
+
+                // Tell the MapDrawer that here is something thats changed
+                #if RIMWORLD15
+                Find.CurrentMap.mapDrawer.MapMeshDirty(Position, MapMeshFlagDefOf.Things, true, false);
+                #else
+                Find.CurrentMap.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
+                #endif
             }
         }
 

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -202,7 +202,6 @@ namespace BetterRimworlds.Stargate
                         chargeSpeed -= 2;
                         Log.Error("0b: " + chargeSpeed);
                         this.updatePowerDrain();
-                        this.updatePowerDrain();
                     }
 
                     float excessPower = this.power.PowerNet.CurrentEnergyGainRate() / CompPower.WattsToWattDaysPerTick;

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -581,7 +581,6 @@ namespace BetterRimworlds.Stargate
                 Log.Message($"Loading the relationship between {relationship.pawn1ID} and {relationship.pawn2ID}: {relationship.relationship}");
 
                 var pawn1 = Find.CurrentMap.mapPawns.AllPawnsSpawned.FirstOrDefault(p => p.ThingID == relationship.pawn1ID);
-                var pawn2 = Find.CurrentMap.mapPawns.AllPawnsSpawned.FirstOrDefault(p => p.ThingID == relationship.pawn2ID);
                 Log.Warning("Pawn 1 (" + relationship.pawn1ID + ") with Pawn 2 (" + relationship.pawn2ID + ") related: " + relationship.relationship);
                 if (pawn1 is null)
                 {
@@ -589,10 +588,12 @@ namespace BetterRimworlds.Stargate
                     continue;
                 }
 
-                if (pawn2 is null)
+                var pawn2 = Find.CurrentMap.mapPawns.AllPawnsSpawned.FirstOrDefault(p =>
+                    p.thingIDNumber == relationship.pawn2ID);
+
+                if (pawn2 == null)
                 {
-                    // Log.Error($"Could not find a pawn with the ID of {relationship.pawn2ID}.");
-                    continue;
+                    pawn2 = StargateBuffer.GenerateMissingRelationshipRecord(relationship.pawn2ID, relationship.pawn2Name);
                 }
 
                 PawnRelationDef pawnRelationDef = DefDatabase<PawnRelationDef>.GetNamedSilentFail(relationship.relationship);

--- a/Source/Stargate/Stargate/Building_Stargate.cs
+++ b/Source/Stargate/Stargate/Building_Stargate.cs
@@ -181,10 +181,8 @@ namespace BetterRimworlds.Stargate
 
             if (!this.stargateBuffer.Any())
             {
-                Log.Error("0");
                 if (this.fullyCharged == true)
                 {
-                    Log.Error("0a");
                     this.stargateBuffer.SetRequiredStargatePower();
                     chargeSpeed = 0;
                     this.updatePowerDrain();
@@ -192,7 +190,7 @@ namespace BetterRimworlds.Stargate
 
                 if (this.fullyCharged == false && this.PoweringUp == true)
                 {
-                    Log.Error("1: " + chargeSpeed);
+                    // Log.Warning("1: " + chargeSpeed);
                     currentCapacitorCharge += chargeSpeed;
                     this.updatePowerDrain();
 
@@ -200,36 +198,35 @@ namespace BetterRimworlds.Stargate
                     if (this.power.PowerOn == false)
                     {
                         chargeSpeed -= 2;
-                        Log.Error("0b: " + chargeSpeed);
                         this.updatePowerDrain();
                     }
 
                     float excessPower = this.power.PowerNet.CurrentEnergyGainRate() / CompPower.WattsToWattDaysPerTick;
-                    Log.Warning("2: Excess Power: " + excessPower + " | Current Stored Energy: " +
-                                (this.power.PowerNet.CurrentStoredEnergy() * 1000));
-                    Log.Warning("Excess Power Calculation: CurrentEnergyGainRate: " +
-                                this.power.PowerNet.CurrentEnergyGainRate() + " | WattsToWattDaysPerTick: " +
-                                CompPower.WattsToWattDaysPerTick);
+                    // Log.Warning("2: Excess Power: " + excessPower + " | Current Stored Energy: " +
+                                // (this.power.PowerNet.CurrentStoredEnergy() * 1000));
+                    // Log.Warning("Excess Power Calculation: CurrentEnergyGainRate: " +
+                                // this.power.PowerNet.CurrentEnergyGainRate() + " | WattsToWattDaysPerTick: " +
+                                // CompPower.WattsToWattDaysPerTick);
 
                     if (excessPower + (this.power.PowerNet.CurrentStoredEnergy() * 1000) > 5000)
                     {
                         chargeSpeed = (int)Math.Round(((excessPower - (excessPower % 1_000)) / 1000) +
                                                       this.power.PowerNet.CurrentStoredEnergy() * 0.25 / 10);
-                        Log.Error("3a: Charge Speed: " + chargeSpeed + " | Excess Power: " +
-                                  ((int)Math.Round(((excessPower - (excessPower % 1_000)) / 1000))) +
-                                  " | Stored Energy: " + (this.power.PowerNet.CurrentStoredEnergy() * 0.25 / 10));
+                        // Log.Warning("3a: Charge Speed: " + chargeSpeed + " | Excess Power: " +
+                                    // ((int)Math.Round(((excessPower - (excessPower % 1_000)) / 1000))) +
+                                    // " | Stored Energy: " + (this.power.PowerNet.CurrentStoredEnergy() * 0.25 / 10));
                         this.updatePowerDrain();
                     }
                     else if (excessPower + (this.power.PowerNet.CurrentStoredEnergy() * 1000) > 1000)
                     {
                         chargeSpeed += 1;
-                        Log.Error("3b: Charge Speed: " + chargeSpeed);
+                        // Log.Warning("3b: Charge Speed: " + chargeSpeed);
                         this.updatePowerDrain();
                     }
                     else
                     {
                         chargeSpeed -= (int)Math.Round((excessPower - (excessPower % 1_000)) / 1000);
-                        Log.Error("3c: Charge Speed: " + chargeSpeed);
+                        // Log.Warning("3c: Charge Speed: " + chargeSpeed);
                         this.updatePowerDrain();
                     }
                 }

--- a/Source/Stargate/Stargate/GateTravelerImplant.cs
+++ b/Source/Stargate/Stargate/GateTravelerImplant.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Enhanced_Development.Stargate.Saving;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate
+{
+    public class GateTravelerImplant : Hediff_Implant
+    {
+        public List<StargateRelation> relationships = new List<StargateRelation>();
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Collections.Look<StargateRelation>(ref this.relationships, "relationships");
+        }
+
+        public override void PostMake()
+        {
+            base.PostMake();
+        }
+    }
+}

--- a/Source/Stargate/Stargate/Saving/SaveThings.cs
+++ b/Source/Stargate/Stargate/Saving/SaveThings.cs
@@ -1,45 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Verse;
 using System.Xml;
-using RimWorld;
+using BetterRimworlds.Stargate;
 
 namespace Enhanced_Development.Stargate.Saving
 {
-    public class StargateRelation: IExposable
-    {
-        public string pawn1ID;
-        public string pawn2ID;
-        public string relationship;
-
-        public StargateRelation()
-        {
-        }
-
-        public StargateRelation(string pawn1ID, string pawn2ID, string relationship)
-        {
-            this.pawn1ID = pawn1ID;
-            this.pawn2ID = pawn2ID;
-            this.relationship = relationship;
-        }
-
-        public void ExposeData()
-        {
-            Scribe_Values.Look(ref pawn1ID, "pawn1");
-            Scribe_Values.Look(ref pawn2ID, "pawn2");
-            Scribe_Values.Look(ref relationship, "relationship");
-            // Scribe_Values.Look<DirectPawnRelation>(ref relationship, "relationship", LookMode.Deep);
-            // Scribe_Deep.Look(ref relationship, "relationship");
-            
-             
-            // Scribe_Defs.Look(ref relationshipDef, "relationship");
-
-        }
-    }
-
     public class StargateRelations: List<StargateRelation>
     {
         private List<StargateRelation> relationships = new List<StargateRelation>();

--- a/Source/Stargate/Stargate/StargateBuffer.cs
+++ b/Source/Stargate/Stargate/StargateBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using RimWorld;
 using RimWorld.Planet;
 using Verse;
@@ -244,6 +245,20 @@ namespace BetterRimworlds.Stargate
             BodyPartRecord brain = pawn.RaceProps.body.AllParts.Find(bpr => bpr.def.defName == "Brain");
 
             pawn.health.AddHediff(gateTravelerImplant, brain);
+        }
+
+        public static bool ClearExistingWorldPawn(Pawn pawn)
+        {
+            // See if the pawn exists in the Dead WorldPawns, and if so, remove the record, because now she/he is back!
+            Messages.Message($"Removed dead world pawn: {pawn.Name.ToStringFull}", MessageTypeDefOf.NeutralEvent);
+            Pawn pawnToRemove = Find.WorldPawns.AllPawnsDead.FirstOrDefault(p => p.thingIDNumber == pawn.thingIDNumber);
+            if (pawnToRemove != null)
+            {
+                Find.WorldPawns.RemovePawn(pawnToRemove);
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Source/Stargate/Stargate/StargateBuffer.cs
+++ b/Source/Stargate/Stargate/StargateBuffer.cs
@@ -118,6 +118,8 @@ namespace BetterRimworlds.Stargate
             {
                 // Increase the maxStacks size for every Pawn, as they don't affect the dispersion area.
                 ++this.maxStacks;
+
+                this.AttachGateTravelerImplant(pawn);
             }
             else
             {
@@ -233,6 +235,15 @@ namespace BetterRimworlds.Stargate
             Find.WorldPawns.PassToWorld(missingPawn, PawnDiscardDecideMode.Decide);
 
             return missingPawn;
+        }
+
+        private void AttachGateTravelerImplant(Pawn pawn)
+        {
+            HediffDef gateTravelerImplant = HediffDef.Named("GateTravelerImplant");
+
+            BodyPartRecord brain = pawn.RaceProps.body.AllParts.Find(bpr => bpr.def.defName == "Brain");
+
+            pawn.health.AddHediff(gateTravelerImplant, brain);
         }
     }
 }

--- a/Source/Stargate/Stargate/StargateBuffer.cs
+++ b/Source/Stargate/Stargate/StargateBuffer.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using Enhanced_Development.Stargate.Saving;
 using RimWorld;
+using RimWorld.Planet;
 using Verse;
 
 namespace BetterRimworlds.Stargate
 {
     public class StargateBuffer : ThingOwner<Thing>, IList<Thing>
     {
-        // private Dictionary<string, Dictionary<stri-ng, PawnRelationDef>> relationships = new Dictionary<string, Dictionary<string, PawnRelationDef>>();
-        public StargateRelations relationships = new StargateRelations();
-
         protected String StargateBufferFilePath;
         protected int numberOfPawns = 0;
 
@@ -121,22 +118,6 @@ namespace BetterRimworlds.Stargate
             {
                 // Increase the maxStacks size for every Pawn, as they don't affect the dispersion area.
                 ++this.maxStacks;
-                foreach (var relationship in pawn.relations.DirectRelations)
-                {
-                    // See if this relation is already recorded using the other pawn as the primary.
-                    if (relationships.ContainsRelationship(relationship.otherPawn.ThingID, pawn.ThingID))
-                    {
-                        continue;
-                    }
-
-                    // // Only record if the other pawn is in the same outgoing buffer.
-                    // if (loadedPawnIds.Contains(relation.otherPawn.ThingID) == false)
-                    // {
-                    //     continue;
-                    // }
-
-                    relationships.Add(new StargateRelation(pawn.ThingID, relationship.otherPawn.ThingID, relationship.def.defName));
-                }
             }
             else
             {
@@ -165,6 +146,7 @@ namespace BetterRimworlds.Stargate
             for (int a = this.InnerListForReading.Count - 1; a >= 0; --a)
             {
                 var thing = this.InnerListForReading[a];
+
                 thing.Destroy();
             }
 
@@ -196,6 +178,61 @@ namespace BetterRimworlds.Stargate
         {
             this.storedMass = 0;
             this.Clear();
+        }
+
+        public static Pawn GenerateMissingRelationshipRecord(int thingID, Name pawnName)
+        {
+            // Create a pawn generation request.
+            // Here we use PawnKindDefOf.Colonist as a placeholder.
+            // You may wish to use another kind that fits your mod better.
+            PawnGenerationRequest request = new PawnGenerationRequest(
+                kind: PawnKindDefOf.Colonist,
+                faction: null, // No faction: it’s not really “alive” in this game.
+                context: PawnGenerationContext.NonPlayer,
+                forceGenerateNewPawn: true);
+
+            Pawn missingPawn = PawnGenerator.GeneratePawn(request);
+            missingPawn.relations.everSeenByPlayer = true;
+
+            // Set the pawn's name to what we want.
+            missingPawn.Name = pawnName;
+
+            // If an existing pawn has the same thingID then,
+            var existingPawn = Find.WorldPawns.AllPawnsAliveOrDead.Find(p => p.thingIDNumber == thingID);
+            if (existingPawn != null)
+            {
+                // Give them a random ThingID if they aren't named the same. It won't really matter.
+                if (existingPawn.Name != pawnName)
+                {
+                    existingPawn.thingIDNumber = -1;
+                    Verse.ThingIDMaker.GiveIDTo(existingPawn);
+                }
+                else
+                {
+                    // If they have the same name, they're the same entity from another universe.
+                    // So give the new guy a random ThingID...
+                    Verse.ThingIDMaker.GiveIDTo(missingPawn);
+                }
+            }
+
+            // Now override the automatically-assigned thingIDNumber with our saved thingID.
+            missingPawn.thingIDNumber = thingID;
+
+            // Ensure the pawn is not spawned anywhere.
+            if (missingPawn.Spawned)
+            {
+                missingPawn.DeSpawn();
+            }
+
+            // Now destroy the pawn so that she/he is marked as "Missing" and can never respawn.
+            missingPawn.Destroy();
+
+            // Register the pawn with the WorldPawns list.
+            // This will flag the pawn as a “world pawn” (i.e. not present on any map)
+            // so that if other pawns refer to it in relationships, it appears as Missing.
+            Find.WorldPawns.PassToWorld(missingPawn, PawnDiscardDecideMode.Decide);
+
+            return missingPawn;
         }
     }
 }

--- a/Source/Stargate/Stargate/StargateRelation.cs
+++ b/Source/Stargate/Stargate/StargateRelation.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace BetterRimworlds.Stargate
+{
+    public class StargateRelation: IExposable
+    {
+        public int pawn1ID;
+        public int pawn2ID;
+        public Name pawn2Name;
+        public string relationship;
+
+        public StargateRelation()
+        {
+        }
+
+        public void ExposeData()
+        {
+            Scribe_Values.Look(ref pawn1ID, "pawn1");
+            Scribe_Values.Look(ref pawn2ID, "pawn2");
+            // Scribe_Values.Look(ref pawn2Name, "pawn2Name");
+            Scribe_Deep.Look(ref pawn2Name, "pawn2Name");
+            Scribe_Values.Look(ref relationship, "relationship");
+            // Scribe_Values.Look<DirectPawnRelation>(ref relationship, "relationship", LookMode.Deep);
+            // Scribe_Deep.Look(ref relationship, "relationship");
+
+
+            // Scribe_Defs.Look(ref relationshipDef, "relationship");
+        }
+
+        public StargateRelation(int pawn1ID, Pawn pawn2, string relationship)
+        {
+            this.pawn1ID = pawn1ID;
+            this.pawn2ID = pawn2.thingIDNumber;
+            this.pawn2Name = pawn2.Name;
+            this.relationship = relationship;
+        }
+    }
+}

--- a/Stargate/Defs/HediffDefs/GateTravelerImplant.xml
+++ b/Stargate/Defs/HediffDefs/GateTravelerImplant.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+    <!-- Gate Traveler Implament -->
+
+    <HediffDef ParentName="ImplantHediffBase">
+        <defName>GateTravelerImplant</defName>
+        <label>Stargate Traveler Implant</label>
+        <labelNoun>a gate traveler implant</labelNoun>
+        <description>Keeps track of info pertinent to gate travel.</description>
+        <hediffClass>BetterRimworlds.Stargate.GateTravelerImplant</hediffClass>
+        <stages>
+            <li>
+            </li>
+        </stages>
+        <comps>
+        </comps>
+    </HediffDef>
+
+</Defs>

--- a/prompts/Missing Pawn Relationships Fix.txt
+++ b/prompts/Missing Pawn Relationships Fix.txt
@@ -1,0 +1,64 @@
+I am creating a mod for Rimworld, a Stargate that sends Pawns and Things from one saved game to another. Rimworld was never designed with this in mind and the mod hacks the game in order to accomplish this.
+
+One of the biggest problems is that pawns' existing relationships, such as husband and wife, are lost when they don't travel through the stargate together. In order to solve this, the Stargate implants a GateTraveler brain implant when they go through the gate which records their unique ThingID, their partner's ThingID, and their partner's full name.
+
+The idea being, if they ever see someone with that same thingID and same full name, they can be relatively confident it's the same exact pawn, and restore a relationship whenever gate travel occurs and they both end up in the same savegame.
+
+However, there is a big challenge: When the partner pawn does not exist in a new savegame, they need to be listed as "Missing". We do this by creating a new pawn with the partner's identity (same ThingID and same Full Name) but the specs don't matter, as this entity should never be spawned. 
+
+Here's the code:
+
+        public static Pawn CreateMissingWorldPawn(int thingID, Name pawnName)
+        {
+            // Create a pawn generation request.
+            // Here we use PawnKindDefOf.Colonist as a placeholder.
+            // You may wish to use another kind that fits your mod better.
+            PawnGenerationRequest request = new PawnGenerationRequest(
+                kind: PawnKindDefOf.Colonist,
+                faction: null, // No faction: it’s not really “alive” in this game.
+                context: PawnGenerationContext.NonPlayer,
+                forceGenerateNewPawn: true);
+
+            Pawn missingPawn = PawnGenerator.GeneratePawn(request);
+
+            // Set the pawn's name to what we want.
+            missingPawn.Name = pawnName;
+
+            // If an existing pawn has the same thingID then,
+            var existingPawn = Find.WorldPawns.AllPawnsAliveOrDead.Find(p => p.thingIDNumber == thingID);
+            if (existingPawn != null)
+            {
+                // Give them a random ThingID if they aren't named the same. It won't really matter.
+                if (existingPawn.Name != pawnName)
+                {
+                    existingPawn.thingIDNumber = -1;
+                    Verse.ThingIDMaker.GiveIDTo(existingPawn);
+                }
+                else
+                {
+                    // If they have the same name, they're the same entity from another universe.
+                    // So give the new guy a random ThingID...
+                    Verse.ThingIDMaker.GiveIDTo(missingPawn);
+                }
+            }
+
+            // Now override the automatically-assigned thingIDNumber with our saved thingID.
+            missingPawn.thingIDNumber = thingID;
+
+            // Ensure the pawn is not spawned anywhere.
+            if (missingPawn.Spawned)
+            {
+                missingPawn.DeSpawn();
+            }
+
+            // Register the pawn with the WorldPawns list.
+            // This will flag the pawn as a “world pawn” (i.e. not present on any map)
+            // so that if other pawns refer to it in relationships, it appears as Missing.
+            Find.WorldPawns.PassToWorld(missingPawn, PawnDiscardDecideMode.Decide);
+
+            return missingPawn;
+        }
+
+This code *does* create a worldpawn with the same ThingID and Full Name, but unfortunately, the relationship does NOT show up in the Bio section of the primary pawn. 
+
+Any ideas how to fix?


### PR DESCRIPTION
This PR fixes all known bugs with the RimWorld Relationships system and intraplanetary (savegame 1 -> savegame 2 -> savegame 1) stargate transmission of Pawns.

It also solves 90% of the remaining Stargate Sickness, which requires a save and reload after Colonists are transmitted.

The only known symptom of Stargate Sickness that remains is that colonists cannot access carried weapons when recruited immediately after arriving on a new world.