### PR TITLE
Added comprehensive scenario for Atlantis Rising and Tok'ra for a stargate base.

### DIFF
--- a/Source/Scenario/README.md
+++ b/Source/Scenario/README.md
@@ -1,0 +1,143 @@
+# Stargate Scenario & Map Generation
+
+This directory contains the map generation and scenario setup code for the BetterRimworlds Stargate mod.
+
+## File Organization
+
+### Core Scenario
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `ScenPart_StargateFacility.cs` | Entry point, orchestration, fog handling, scenario messages | ~85 |
+| `ScenPart_StargateFacility.Structure.cs` | Room construction, walls, floors, Stargate placement, equipment, casket, roof | ~140 |
+| `ScenPart_StargateFacility.Power.cs` | Power conduit network generation | ~60 |
+| `ScenPart_StargateFacility.Details.cs` | Lighting, debris, survival meals, home area, colonist spawning | ~95 |
+| `ScenPart_StargateFacility.Clearing.cs` | Footprint clearing, cell preparation for building | ~75 |
+| `ScenPart_StargateFacility.Helpers.cs` | `PlaceClaimed`, tile description, rotation utilities | ~110 |
+
+**Total:** ~566 lines across 6 focused files (was 766 in single file)
+
+### Destination Map Generation
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `StargateDestinationMapGen.cs` | Entry point, underlay terrain, dispatch to generators | ~50 |
+| `StargateDestinationMapGen.Ocean.cs` | Atlantis-style water surroundings | ~60 |
+| `StargateDestinationMapGen.Cavern.cs` | Tok'ra-style mountain base with caverns, flora, ore | ~170 |
+
+**Total:** ~280 lines across 3 focused files
+
+## Design Patterns
+
+### Partial Classes
+
+All scenario and map generation classes use C# `partial` to split implementation across multiple files while maintaining:
+
+- Shared private constants (`RoomSize`, `WooshRadius`)
+- Access to private helpers across files
+- Single cohesive class semantics at runtime
+- File-per-domain organization for AI/token efficiency
+
+### Generation Pipeline
+
+```
+ScenPart_StargateFacility.GenerateIntoMap()
+    │
+    ├── ClearFacilityFootprint()     // Remove obstructions
+    ├── StargateDestinationMapGen.Apply()  // Tile-specific terrain (Ocean/Impassable)
+    │
+    ├── GenerateRoomStructure()      // Walls, floors, door
+    ├── PlaceRoof()                  // Constructed roof over facility
+    ├── PlacePowerConduits()         // Power network
+    ├── PlaceStargate()              // Main building
+    ├── PlaceSupportEquipment()      // Vanometric cell, ZPM, DHD, casket
+    ├── PlaceSurvivalMeals()         // Starting food
+    ├── AddFacilityDetails()         // Lamps, debris
+    ├── ClaimHomeArea()              // Home zone for colonist AI
+    └── SpawnColonists()             // Player pawns (minus guardian)
+    
+    [Deferred]
+    └── ShowScenarioMessage()        // UI after map ready
+```
+
+### Tile Types
+
+| Description | Generator | Theme |
+|-------------|-----------|-------|
+| `"Ocean"` | `GenerateOceanSurroundings()` | Atlantis — shallow water apron, deep ocean beyond |
+| `"Impassable"` | `GenerateImpassableSurroundings()` | Tok'ra — carved mountain base, caverns, glowstools, ore veins |
+| (default) | Vanilla terrain | Surface facility with natural surroundings |
+
+## Key Implementation Notes
+
+### Room Size Contract
+
+`RoomSize = 15` must match exactly between:
+- `ScenPart_StargateFacility.RoomSize`
+- `StargateDestinationMapGen.RoomSize`
+
+The room is always centered on `map.Center` with this fixed size.
+
+### Facility Underlay
+
+Rich soil is placed under the entire facility footprint before any floors. This enables:
+- **Ocean:** Removing concrete reveals farmable soil (Atlantis gardens)
+- **Impassable:** Underground growing under artificial light
+
+Sequence: `SetTerrain(SoilRich)` → `SetTerrain(Concrete)` → removal restores soil.
+
+### Fog of War Handling
+
+The deferred `LongEventHandler.ExecuteWhenFinished()` block:
+1. Forces `MapDrawer` section allocation (prevents NPEs with RocketMan)
+2. Refogs entire map
+3. Flood-unfogs from walkable seed cell inside room
+4. Redraws fog and things
+5. Shows scenario message dialog
+
+### Cavern Generation (Impassable)
+
+| Phase | Action |
+|-------|--------|
+| 1 | Fill map with solid rock + thick roof (preserve facility area) |
+| 2 | Carve 5-9 small caverns (6-14 cells each) with organic shapes |
+| 3 | Plant glowstool/agarilux/bryolux in carved cells |
+| 4 | Scatter rich ore deposits across all rock |
+| 5 | Place guaranteed ore veins on cavern walls (~25% conversion) |
+
+### The Guardian
+
+First pawn in `startingAndOptionalPawns` is placed in a cryptosleep casket. This pawn:
+- Does not spawn normally with other colonists
+- Is preserved for narrative/story purposes
+- Awakens when casket is opened
+
+## Version Compatibility
+
+Preprocessor directives handle RimWorld version differences:
+
+| Directive | Versions | Purpose |
+|-----------|----------|---------|
+| `RIMWORLD12` | 1.2 | `DefDatabase<TerrainDef>.GetNamed("SoilRich")` vs `TerrainDefOf.SoilRich` |
+| `RIMWORLD15 \|\| RIMWORLD16` | 1.5+ | `MapMeshFlagDefOf` vs `MapMeshFlag`, `FogGrid.Refog()` vs manual array |
+
+## Dependencies
+
+- **Royalty DLC:** `VanometricPowerCell`, `Plant_Agarilux`, `Plant_Bryolux` (graceful fallback if absent)
+- **Modded:** `ArchotechZPM`, `StargateDHD` (graceful fallback if absent)
+- **Core:** All other ThingDefs are vanilla
+
+## Adding New Tile Types
+
+1. Add case in `DescribeTile()` (Helpers file)
+2. Create `StargateDestinationMapGen.YourType.cs`
+3. Add dispatch in `StargateDestinationMapGen.Apply()`
+
+Example:
+```csharp
+case "YourType":
+    GenerateYourTypeSurroundings(map);
+    break;
+```
+
+Maintain the pattern: file-per-type, all `partial` in same class, shared constants from main file.

--- a/Source/Scenario/ScenPart_StargateFacility.Clearing.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.Clearing.cs
@@ -1,0 +1,77 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.Clearing.cs ====
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility
+{
+    private void ClearFacilityFootprint(Map map, CellRect rect)
+    {
+        foreach (IntVec3 cell in rect.Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+
+            List<Thing> things = map.thingGrid.ThingsListAt(cell).ToList();
+            foreach (Thing thing in things)
+            {
+                if (thing is Pawn) continue;
+
+                if (thing.def.destroyable ||
+                    thing.def.category == ThingCategory.Building ||
+                    thing.def.category == ThingCategory.Plant ||
+                    thing.def.category == ThingCategory.Item)
+                {
+                    thing.Destroy();
+                }
+            }
+        }
+    }
+
+    private void ClearCellForDoorway(Map map, IntVec3 cell)
+    {
+        if (!cell.InBounds(map)) return;
+
+        List<Thing> existing = map.thingGrid.ThingsListAt(cell).ToList();
+        foreach (Thing thing in existing)
+        {
+            if (thing is Pawn) continue;
+
+            if (thing.def == ThingDefOf.Wall ||
+                thing.def == ThingDefOf.Door ||
+                thing.def.destroyable ||
+                thing.def.category == ThingCategory.Building ||
+                thing.def.category == ThingCategory.Plant ||
+                thing.def.category == ThingCategory.Item)
+            {
+                thing.Destroy();
+            }
+        }
+
+        map.terrainGrid.SetTerrain(cell, TerrainDefOf.Concrete);
+    }
+
+    private void ClearCellForBuilding(Map map, IntVec3 cell)
+    {
+        if (!cell.InBounds(map)) return;
+
+        List<Thing> existing = map.thingGrid.ThingsListAt(cell).ToList();
+        foreach (Thing thing in existing)
+        {
+            if (thing is Pawn) continue;
+
+            if (thing.def == ThingDefOf.Wall ||
+                thing.def == ThingDefOf.Door ||
+                thing.def == ThingDefOf.SteamGeyser ||
+                thing.def == ThingDefOf.ChunkSlagSteel ||
+                thing.def == ThingDefOf.Filth_RubbleBuilding ||
+                thing.def.category == ThingCategory.Building ||
+                thing.def.category == ThingCategory.Plant)
+            {
+                thing.Destroy();
+            }
+        }
+    }
+}

--- a/Source/Scenario/ScenPart_StargateFacility.Details.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.Details.cs
@@ -1,0 +1,272 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.Details.cs ====
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility
+{
+    private void AddFacilityDetails(Map map, CellRect roomRect, IntVec3 center)
+    {
+        IntVec3[] lampPositions = new[]
+        {
+            new IntVec3(roomRect.minX + 3, 0, roomRect.minZ + 3),
+            new IntVec3(roomRect.maxX - 3, 0, roomRect.minZ + 3),
+            new IntVec3(roomRect.minX + 3, 0, roomRect.maxZ - 3),
+            new IntVec3(roomRect.maxX - 3, 0, roomRect.maxZ - 3)
+        };
+
+        foreach (IntVec3 pos in lampPositions)
+        {
+            if (!pos.InBounds(map)) continue;
+            if (pos.DistanceTo(center) <= WooshRadius) continue;
+
+            ClearCellForBuilding(map, pos);
+            PlaceClaimed(map, ThingDefOf.StandingLamp, pos);
+        }
+
+        // Ancient debris - strictly outside the woosh radius.
+        // Debris stays unclaimed/unfactioned by design (it's loose junk).
+        for (int i = 0; i < 12; i++)
+        {
+            IntVec3 debrisPos = CellFinder.RandomClosewalkCellNear(roomRect.CenterCell, map, 6);
+
+            if (!debrisPos.InBounds(map)) continue;
+            if (debrisPos.DistanceTo(center) <= WooshRadius) continue;
+            if (!roomRect.Contains(debrisPos)) continue;
+            if (!debrisPos.Walkable(map)) continue;
+
+            ThingDef debrisDef = Rand.Bool ? ThingDefOf.ChunkSlagSteel : ThingDefOf.Filth_RubbleBuilding;
+            Thing debris = ThingMaker.MakeThing(debrisDef);
+            GenPlace.TryPlaceThing(debris, debrisPos, map, ThingPlaceMode.Near);
+        }
+    }
+
+    private void PlaceDiningArea(Map map, CellRect roomRect, IntVec3 center)
+    {
+        ThingDef tableDef = DefDatabase<ThingDef>.GetNamedSilentFail("Table2x4c");
+        if (tableDef == null) { Log.Warning("[Stargate] Could not place dining area: missing Table2x4c."); return; }
+
+        CellRect interior = new CellRect(roomRect.minX + 1, roomRect.minZ + 1, roomRect.Width - 2, roomRect.Height - 2);
+        CellRect zpmRect = GetZpmRect(roomRect);
+        CellRect lightRect = GetLightRect(roomRect);
+        bool useNorthWall = _entranceSide != Rot4.North;
+
+        IntVec3 tablePos = FindBestTablePos(interior, tableDef, zpmRect, lightRect, center, useNorthWall);
+        if (!tablePos.IsValid) { Log.Warning("[Stargate] Could not find a valid dining table position."); return; }
+
+        SpawnTable(map, tablePos, tableDef);
+        SpawnChairs(map, tablePos, tableDef, interior, zpmRect, lightRect);
+        PlaceSurvivalMeals(map, interior, tablePos, tableDef, useNorthWall);
+    }
+
+    private CellRect GetZpmRect(CellRect roomRect)
+    {
+        IntVec3 zpmPos = new IntVec3(roomRect.minX + 2, 0, roomRect.maxZ - 2);
+        ThingDef zpmDef = DefDatabase<ThingDef>.GetNamedSilentFail("ArchotechZPM");
+        return zpmDef != null ? GenAdj.OccupiedRect(zpmPos, Rot4.North, zpmDef.size) : new CellRect(zpmPos.x, zpmPos.z, 1, 1);
+    }
+
+    private CellRect GetLightRect(CellRect roomRect)
+    {
+        int centerX = (roomRect.minX + roomRect.maxX) / 2;
+        int centerZ = (roomRect.minZ + roomRect.maxZ) / 2;
+    
+        return new CellRect(centerX, centerZ, 1, 1);
+    }
+
+    private IntVec3 FindBestTablePos(CellRect interior, ThingDef tableDef, CellRect zpmRect, CellRect lightRect, IntVec3 center, bool useNorthWall)
+    {
+        IntVec3 bestPos = IntVec3.Invalid;
+        int bestScore = int.MaxValue;
+        Rot4 tableRot = Rot4.East;
+
+        foreach (IntVec3 candidate in interior.Cells)
+        {
+            CellRect occupied = GenAdj.OccupiedRect(candidate, tableRot, tableDef.size);
+            if (!IsValidPlacement(occupied, interior, zpmRect, lightRect, center, useNorthWall)) continue;
+
+            int score = Mathf.Abs(occupied.minX - (useNorthWall ? zpmRect.maxX + 1 : zpmRect.minX));
+            if (score < bestScore) { bestScore = score; bestPos = candidate; }
+        }
+
+        return bestPos;
+    }
+
+    private bool IsValidPlacement(CellRect occupied, CellRect interior, CellRect zpmRect, CellRect lightRect, IntVec3 center, bool useNorthWall)
+    {
+        bool withinInterior = interior.Contains(new IntVec3(occupied.minX, 0, occupied.minZ)) &&
+                              interior.Contains(new IntVec3(occupied.maxX, 0, occupied.maxZ));
+        if (!withinInterior) return false;
+
+        bool flushWithWall = useNorthWall ? occupied.maxZ == interior.maxZ : occupied.minZ == interior.minZ;
+        if (!flushWithWall) return false;
+
+        if (occupied.Cells.Any(c => c.DistanceTo(center) <= WooshRadius)) return false;
+        if (occupied.Overlaps(zpmRect)) return false;
+        if (occupied.Overlaps(lightRect)) return false;
+
+        return true;
+    }
+
+    private void SpawnTable(Map map, IntVec3 tablePos, ThingDef tableDef)
+    {
+        CellRect tableRect = GenAdj.OccupiedRect(tablePos, Rot4.East, tableDef.size);
+        foreach (IntVec3 cell in tableRect.Cells) ClearCellForBuilding(map, cell);
+
+        Thing table = ThingMaker.MakeThing(tableDef, ThingDefOf.Steel);
+        table.SetFactionDirect(Faction.OfPlayer);
+        GenSpawn.Spawn(table, tablePos, map, Rot4.East);
+    }
+
+    private void SpawnChairs(Map map, IntVec3 tablePos, ThingDef tableDef, CellRect interior, CellRect zpmRect, CellRect lightRect)
+    {
+        ThingDef chairDef = DefDatabase<ThingDef>.GetNamedSilentFail("DiningChair");
+        if (chairDef == null) return;
+
+        CellRect tableRect = GenAdj.OccupiedRect(tablePos, Rot4.East, tableDef.size);
+
+        foreach (IntVec3 cell in GenAdj.CellsAdjacent8Way(tablePos, Rot4.East, tableDef.size))
+        {
+            // Skip cells that are diagonally adjacent to the table's actual rectangle.
+            // This removes the corner chairs, including the far-left and far-right
+            // chairs on the bottom row.
+            bool outsideX = cell.x < tableRect.minX || cell.x > tableRect.maxX;
+            bool outsideZ = cell.z < tableRect.minZ || cell.z > tableRect.maxZ;
+
+            if (outsideX && outsideZ)
+                continue;
+
+            Rot4 chairRot = Rot4.Invalid;
+
+            if (cell.z < tableRect.minZ)
+                chairRot = Rot4.North;
+            else if (cell.z > tableRect.maxZ)
+                chairRot = Rot4.South;
+            else if (cell.x < tableRect.minX)
+                chairRot = Rot4.East;
+            else if (cell.x > tableRect.maxX)
+                chairRot = Rot4.West;
+
+            if (!chairRot.IsValid) continue;
+
+            if (!interior.Contains(cell)) continue;
+
+            if (zpmRect.Contains(cell) || lightRect.Contains(cell)) continue;
+
+            ClearCellForBuilding(map, cell);
+
+            Thing chair = ThingMaker.MakeThing(chairDef, ThingDefOf.Steel);
+            chair.SetFactionDirect(Faction.OfPlayer);
+            GenSpawn.Spawn(chair, cell, map, chairRot);
+        }
+    }
+    
+    // Register the gate room as Home so colonists clean, haul, and repair inside it.
+    // Without this, properly-claimed buildings still don't get baseline base behavior
+    // because the area manager doesn't consider the cells "ours" yet.
+    private void ClaimHomeArea(Map map, CellRect roomRect)
+    {
+        foreach (IntVec3 cell in roomRect.Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+            map.areaManager.Home[cell] = true;
+        }
+    }
+
+    private void SpawnColonists(Map map, IntVec3 center)
+    {
+        if (Find.GameInitData?.startingAndOptionalPawns == null) return;
+
+        IntVec3 spawnSpot = CellFinder.RandomClosewalkCellNear(center + new IntVec3(0, 0, 3), map, 3);
+
+        foreach (Pawn pawn in Find.GameInitData.startingAndOptionalPawns)
+        {
+            if (pawn == null) continue;
+            if (pawn == _guardianPawn) continue; // Same reference, not a second lookup
+            if (pawn.Spawned) continue;
+
+            GenPlace.TryPlaceThing(pawn, spawnSpot, map, ThingPlaceMode.Near);
+        }
+    }
+    
+    private void PlaceSurvivalMeals(Map map, CellRect interior, IntVec3 tablePos, ThingDef tableDef, bool useNorthWall)
+    {
+        ThingDef shelfDef = DefDatabase<ThingDef>.GetNamedSilentFail("Shelf");
+        ThingDef mealDef = ThingDefOf.MealSurvivalPack;
+
+        Rot4 shelfRot = Rot4.East;
+        CellRect tableRect = GenAdj.OccupiedRect(tablePos, Rot4.East, tableDef.size);
+
+        IntVec3 shelfPos = FindSurvivalMealShelfPos(interior, shelfDef, shelfRot, useNorthWall);
+
+        if (!shelfPos.IsValid)
+        {
+            Log.Warning("[Stargate] Could not find a valid shelf position for survival meals.");
+            return;
+        }
+
+        CellRect shelfRect = GenAdj.OccupiedRect(shelfPos, shelfRot, shelfDef.size);
+
+        foreach (IntVec3 cell in shelfRect.Cells)
+            ClearCellForBuilding(map, cell);
+
+        Thing shelf = ThingMaker.MakeThing(shelfDef, ThingDefOf.Steel);
+        shelf.SetFactionDirect(Faction.OfPlayer);
+        GenSpawn.Spawn(shelf, shelfPos, map, shelfRot);
+
+        int placed = 0;
+
+        foreach (IntVec3 cell in shelfRect.Cells)
+        {
+            if (placed >= 2) break;
+
+            Thing meals = ThingMaker.MakeThing(mealDef);
+            meals.stackCount = 10;
+            GenSpawn.Spawn(meals, cell, map);
+
+            placed++;
+        }
+    }
+
+    private IntVec3 FindSurvivalMealShelfPos(
+        CellRect interior,
+        ThingDef shelfDef,
+        Rot4 shelfRot,
+        bool useNorthWall)
+    {
+        IntVec3 bestPos = IntVec3.Invalid;
+        int bestScore = int.MaxValue;
+
+        foreach (IntVec3 candidate in interior.Cells)
+        {
+            CellRect occupied = GenAdj.OccupiedRect(candidate, shelfRot, shelfDef.size);
+
+            if (!interior.Contains(new IntVec3(occupied.minX, 0, occupied.minZ)) ||
+                !interior.Contains(new IntVec3(occupied.maxX, 0, occupied.maxZ)))
+                continue;
+
+            // Put the shelf on the far right/east wall of the room.
+            if (occupied.maxX != interior.maxX)
+                continue;
+
+            // Keep it on the same side of the room as the table:
+            // north-wall table => shelf near north end of east wall
+            // south-wall table => shelf near south end of east wall
+            int targetZ = useNorthWall ? interior.maxZ : interior.minZ;
+
+            int score = Mathf.Abs(occupied.CenterCell.z - targetZ);
+
+            if (score < bestScore)
+            {
+                bestScore = score;
+                bestPos = candidate;
+            }
+        }
+
+        return bestPos;
+    }
+}

--- a/Source/Scenario/ScenPart_StargateFacility.Helpers.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.Helpers.cs
@@ -1,0 +1,141 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.Helpers.cs ====
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility
+{
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    // Spawns a thing at the target cell and properly factions it to the player.
+    //
+    // Why this exists:
+    //   SetFactionDirect is a raw field setter that bypasses Notify_OwnerChanged,
+    //   designation manager registration, and faction tracking. Calling it before
+    //   GenPlace.TryPlaceThing on an unspawned Thing leaves the building "placed"
+    //   but not actually owned by the player - claims don't register, the building
+    //   isn't selectable as ours, and the map drawer doesn't auto-unfog around it.
+    //
+    //   The correct sequence is: MakeThing -> GenSpawn.Spawn -> SetFaction after.
+    //   SetFaction, not SetFactionDirect, fires the ownership notifications.
+    private Thing PlaceClaimed(Map map, ThingDef def, IntVec3 cell, ThingDef stuff = null, Rot4? rotation = null)
+    {
+        if (!cell.InBounds(map)) return null;
+
+        Thing thing = ThingMaker.MakeThing(def, stuff);
+        // Some DLC/modded building defs produce a MinifiedThing wrapper.
+        // GenSpawn.Spawn will place it as a boxed item on the floor rather
+        // than installing it. Unwrap the inner building before spawning.
+        if (thing is MinifiedThing minified)
+        {
+            Thing inner = minified.InnerThing;
+            minified.InnerThing = null; // prevents the wrapper from owning/destroying it
+            thing = inner;
+        }
+
+        if (thing.def.useHitPoints)
+        {
+            thing.HitPoints = thing.MaxHitPoints;
+        }
+
+        Rot4 rot = rotation ?? Rot4.North;
+        Thing spawned = GenSpawn.Spawn(thing, cell, map, rot, WipeMode.Vanish);
+
+        if (spawned != null && spawned.def.CanHaveFaction)
+        {
+            spawned.SetFaction(Faction.OfPlayer);
+        }
+
+        return spawned;
+    }
+
+    // Returns the cardinal Rot4 that points from one cell toward another,
+    // picking the dominant axis. Handles arbitrary offsets, unlike
+    // Rot4.FromIntVec3 which only accepts cardinal unit vectors.
+    private Rot4 GetRotationFacing(IntVec3 from, IntVec3 to)
+    {
+        int dx = to.x - from.x;
+        int dz = to.z - from.z;
+
+        if (System.Math.Abs(dx) >= System.Math.Abs(dz))
+        {
+            return dx >= 0 ? Rot4.East : Rot4.West;
+        }
+
+        return dz >= 0 ? Rot4.North : Rot4.South;
+    }
+
+    private IntVec3 GetCenteredEdgeCell(CellRect rect, Rot4 side)
+    {
+        if (side == Rot4.North)
+        {
+            return new IntVec3(rect.CenterCell.x, 0, rect.maxZ);
+        }
+
+        if (side == Rot4.South)
+        {
+            return new IntVec3(rect.CenterCell.x, 0, rect.minZ);
+        }
+
+        if (side == Rot4.East)
+        {
+            return new IntVec3(rect.maxX, 0, rect.CenterCell.z);
+        }
+
+        return new IntVec3(rect.minX, 0, rect.CenterCell.z);
+    }
+
+    private bool ContainsThingDef(Map map, IntVec3 cell, ThingDef def)
+    {
+        if (!cell.InBounds(map)) return false;
+
+        List<Thing> things = map.thingGrid.ThingsListAt(cell);
+        for (int i = 0; i < things.Count; i++)
+        {
+            if (things[i].def == def)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private Tile GetTile(int tileId)
+    {
+#if RIMWORLD16
+        return Find.WorldGrid[tileId];
+#else
+        return Find.WorldGrid.tiles[tileId];
+#endif
+    }
+
+    private string DescribeTile(int tileId)
+    {
+        if (tileId < 0 || tileId >= Find.WorldGrid.TilesCount) return "Unknown";
+
+        Tile tile = GetTile(tileId);
+        if (tile == null) return "Unknown";
+
+        if (tile.WaterCovered) return "Ocean";
+
+        // This is the actual impassable-mountain marker. biome.impassable is a
+        // different concept (biomes that can never be settled) and is effectively
+        // unused in vanilla 1.2.
+        if (tile.hilliness == Hilliness.Impassable) return "Impassable";
+
+#if RIMWORLD16
+        if (tile.PrimaryBiome != null) return tile.PrimaryBiome.defName;
+#else
+        if (tile.biome != null) return tile.biome.defName;
+#endif
+
+        return "Unknown";
+    }
+}

--- a/Source/Scenario/ScenPart_StargateFacility.Power.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.Power.cs
@@ -1,0 +1,75 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.Power.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility
+{
+    private void PlacePowerConduits(Map map, IntVec3 center, CellRect roomRect)
+    {
+        ThingDef conduitDef = ThingDefOf.PowerConduit;
+        if (conduitDef == null) return;
+
+        // Main deterministic conduit loop just inside the inner wall.
+        // This replaces the previous random broken-grid behavior.
+        CellRect conduitLoopRect = roomRect.ContractedBy(1);
+        foreach (IntVec3 cell in conduitLoopRect.EdgeCells)
+        {
+            TryPlaceConduit(map, cell);
+        }
+
+        // Power spine through the center area.
+        // This connects the Stargate/DHD area to the wall loop.
+        for (int x = roomRect.minX + 2; x <= roomRect.maxX - 2; x++)
+        {
+            TryPlaceConduit(map, new IntVec3(x, 0, center.z));
+        }
+
+        for (int z = roomRect.minZ + 2; z <= roomRect.maxZ - 2; z++)
+        {
+            TryPlaceConduit(map, new IntVec3(center.x, 0, z));
+        }
+
+        // Explicit spurs toward known equipment positions.
+        // DrawConduitLine(map, center, new IntVec3(roomRect.maxX - 2, 0, roomRect.minZ + 2));
+        // DrawConduitLine(map, center, new IntVec3(roomRect.minX + 2, 0, roomRect.maxZ - 2));
+        // DrawConduitLine(map, center, center + new IntVec3(3, 0, 0));
+    }
+
+    private void TryPlaceConduit(Map map, IntVec3 cell)
+    {
+        if (!cell.InBounds(map)) return;
+        if (cell.Impassable(map)) return;
+        if (ContainsThingDef(map, cell, ThingDefOf.PowerConduit)) return;
+
+        PlaceClaimed(map, ThingDefOf.PowerConduit, cell);
+    }
+
+    private void DrawConduitLine(Map map, IntVec3 start, IntVec3 end)
+    {
+        IntVec3 current = start;
+
+        while (current.x != end.x)
+        {
+            current = new IntVec3(
+                current.x + (current.x < end.x ? 1 : -1),
+                0,
+                current.z
+            );
+
+            TryPlaceConduit(map, current);
+        }
+
+        while (current.z != end.z)
+        {
+            current = new IntVec3(
+                current.x,
+                0,
+                current.z + (current.z < end.z ? 1 : -1)
+            );
+
+            TryPlaceConduit(map, current);
+        }
+    }
+}

--- a/Source/Scenario/ScenPart_StargateFacility.Structure.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.Structure.cs
@@ -1,0 +1,226 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.Structure.cs ====
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility
+{
+    private Pawn _guardianPawn;
+    private Rot4 _entranceSide;
+
+    private void GenerateRoomStructure(Map map, CellRect innerRect, CellRect outerRect)
+    {
+        string[] stoneTypes = { "BlocksGranite", "BlocksLimestone", "BlocksSlate" };
+        ThingDef wallMaterial = DefDatabase<ThingDef>.GetNamed(stoneTypes[Rand.Range(0, stoneTypes.Length)]);
+        TerrainDef floorDef = TerrainDefOf.Concrete;
+
+        _entranceSide = Rand.Element(Rot4.North, Rot4.South, Rot4.East, Rot4.West);
+
+        IntVec3 innerDoorCell = GetCenteredEdgeCell(innerRect, _entranceSide);
+        IntVec3 outerDoorCell = GetCenteredEdgeCell(outerRect, _entranceSide);
+        IntVec3 outsideApproachCell = outerDoorCell + _entranceSide.FacingCell;
+
+        // Floor the interior.
+        // Mountain roof is intentionally preserved if present.
+        foreach (IntVec3 cell in innerRect.Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+
+            map.terrainGrid.SetTerrain(cell, floorDef);
+        }
+
+        // Build OUTER wall layer.
+        foreach (IntVec3 cell in outerRect.EdgeCells)
+        {
+            if (!cell.InBounds(map)) continue;
+
+            // The outer wall doorway must stay open.
+            // The actual door goes on the inner wall.
+            if (cell == outerDoorCell) continue;
+
+            ClearCellForBuilding(map, cell);
+            PlaceClaimed(map, ThingDefOf.Wall, cell, wallMaterial);
+        }
+
+        // Build INNER wall layer.
+        foreach (IntVec3 cell in innerRect.EdgeCells)
+        {
+            if (!cell.InBounds(map)) continue;
+
+            // The inner wall receives the actual single centered door.
+            if (cell == innerDoorCell) continue;
+
+            ClearCellForBuilding(map, cell);
+            PlaceClaimed(map, ThingDefOf.Wall, cell, wallMaterial);
+        }
+
+        // Doorway cells are sacred.
+        // Clear the inner wall door cell, the outer wall passage cell,
+        // and one exterior approach cell so no natural rock wall can block access.
+        ClearCellForDoorway(map, innerDoorCell);
+        ClearCellForDoorway(map, outerDoorCell);
+        ClearCellForDoorway(map, outsideApproachCell);
+
+        // Exactly one door, centered, randomly oriented N/S/E/W by entrance side.
+        // Placing the door on the inner wall preserves the 2-thick ancient wall look
+        // while preventing the outer wall from blocking it.
+        PlaceDoor(map, innerDoorCell, wallMaterial);
+    }
+
+    private void PlaceStargate(Map map, IntVec3 center)
+    {
+        ThingDef stargateDef = DefDatabase<ThingDef>.GetNamedSilentFail("Stargate");
+
+        if (stargateDef == null)
+        {
+            Log.Warning("BetterRimworlds.Stargate: Stargate ThingDef not found.");
+            return;
+        }
+
+        CellRect stargateRect = new CellRect(center.x - 1, center.z - 1, 3, 3);
+
+        // CRITICAL:
+        // Remove ANY steam geysers in the stargate area and immediate vicinity.
+        foreach (IntVec3 cell in stargateRect.ExpandedBy(2).Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+
+            List<Thing> things = map.thingGrid.ThingsListAt(cell).ToList();
+            foreach (Thing thing in things)
+            {
+                if (thing is Pawn) continue;
+
+                if (thing.def == ThingDefOf.SteamGeyser)
+                {
+                    thing.Destroy();
+                }
+                else if (thing.def.destroyable && thing.def != ThingDefOf.Wall)
+                {
+                    thing.Destroy();
+                }
+            }
+        }
+
+        Thing stargate = PlaceClaimed(map, stargateDef, center);
+        if (stargate != null)
+        {
+            CompPowerTrader powerComp = stargate.TryGetComp<CompPowerTrader>();
+            if (powerComp != null)
+            {
+                powerComp.PowerOn = true;
+            }
+        }
+    }
+
+    private void PlaceSupportEquipment(Map map, IntVec3 center, CellRect roomRect)
+    {
+        // 1. Vanometric Power Cell (Royalty) - mandatory power source.
+        ThingDef vanoDef = DefDatabase<ThingDef>.GetNamedSilentFail("VanometricPowerCell");
+        if (vanoDef != null)
+        {
+            IntVec3 vanoPos = new IntVec3(roomRect.maxX - 2, 0, roomRect.minZ + 2);
+            if (vanoPos.InBounds(map))
+            {
+                ClearCellForBuilding(map, vanoPos);
+                PlaceClaimed(map, vanoDef, vanoPos);
+            }
+        }
+
+        // 2. Archotech ZPM at 75% charge, if mod present.
+        ThingDef zpmDef = DefDatabase<ThingDef>.GetNamedSilentFail("ArchotechZPM");
+        if (zpmDef != null)
+        {
+            IntVec3 zpmPos = new IntVec3(roomRect.minX + 2, 0, roomRect.maxZ - 2);
+            if (zpmPos.InBounds(map))
+            {
+                ClearCellForBuilding(map, zpmPos);
+
+                Thing zpm = PlaceClaimed(map, zpmDef, zpmPos);
+                if (zpm != null)
+                {
+                    CompPowerBattery batteryComp = zpm.TryGetComp<CompPowerBattery>();
+                    if (batteryComp != null)
+                    {
+                        batteryComp.SetStoredEnergyPct(0.75f);
+                    }
+                }
+            }
+        }
+
+        // 3. DHD placement.
+        ThingDef dhdDef = DefDatabase<ThingDef>.GetNamedSilentFail("StargateDHD");
+        if (dhdDef != null)
+        {
+            IntVec3 dhdPos = center + new IntVec3(3, 0, 0);
+            if (dhdPos.InBounds(map) && dhdPos.Walkable(map))
+            {
+                ClearCellForBuilding(map, dhdPos);
+                PlaceClaimed(map, dhdDef, dhdPos);
+            }
+        }
+
+        // 4. The Guardian's Casket
+        IntVec3 casketPos = center + new IntVec3(-4, 0, 0);
+        if (casketPos.InBounds(map))
+        {
+            ClearCellForBuilding(map, casketPos);
+
+            Building_CryptosleepCasket casket = (Building_CryptosleepCasket)PlaceClaimed(
+                map, ThingDefOf.AncientCryptosleepCasket, casketPos, rotation: Rot4.East
+            );
+
+            _guardianPawn = GetGuardianPawn();
+            if (_guardianPawn != null && casket != null)
+            {
+                casket.TryAcceptThing(_guardianPawn, false);
+            }
+        }
+        
+    }
+
+    private Pawn GetGuardianPawn()
+    {
+        if (Find.GameInitData == null || Find.GameInitData.startingAndOptionalPawns == null)
+        {
+            return null;
+        }
+
+        return Find.GameInitData.startingAndOptionalPawns.FirstOrDefault();
+    }
+
+    private void PlaceDoor(Map map, IntVec3 cell, ThingDef material)
+    {
+        // We use ClearCellForBuilding instead of ClearCellForDoorway
+        // to ensure it clears the concrete floor too, if you don't want it under the wall.
+        ClearCellForBuilding(map, cell);
+
+        // NOTE:
+        // This places a functional door. If you want the sealed-ancient-ruin aesthetic,
+        // swap ThingDefOf.Door back to ThingDefOf.Wall here.
+        PlaceClaimed(map, ThingDefOf.Door, cell, material);
+    }
+
+    private void PlaceRoof(Map map, CellRect roomRect)
+    {
+        RoofDef roof = RoofDefOf.RoofConstructed;
+
+        foreach (IntVec3 cell in roomRect.Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+            map.roofGrid.SetRoof(cell, roof);
+        }
+
+        // Roof the 2-thick outer wall band too so there's no gap at the edges.
+        foreach (IntVec3 cell in roomRect.ExpandedBy(1).Cells)
+        {
+            if (!cell.InBounds(map)) continue;
+            if (map.roofGrid.RoofAt(cell) == null)
+            {
+                map.roofGrid.SetRoof(cell, roof);
+            }
+        }
+    }
+}

--- a/Source/Scenario/ScenPart_StargateFacility.cs
+++ b/Source/Scenario/ScenPart_StargateFacility.cs
@@ -1,0 +1,194 @@
+// ==== Source/Scenario/ScenPart_StargateFacility.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+internal partial class ScenPart_StargateFacility : ScenPart
+{
+    // Must match StargateDestinationMapGen.RoomSize exactly.
+    private const int RoomSize = 15;
+    private const float WooshRadius = 4.9f; // Kawoosh kills everything within ~5 tiles
+
+    public override void GenerateIntoMap(Map map)
+    {
+        IntVec3 center = map.Center;
+        int halfSize = RoomSize / 2;
+
+        // Define room boundaries.
+        // This rect includes the inner wall layer on its edge.
+        CellRect roomRect = new CellRect(
+            center.x - halfSize,
+            center.z - halfSize,
+            RoomSize,
+            RoomSize
+        );
+
+        // Outer rect for 2-thick walls.
+        CellRect outerWallRect = roomRect.ExpandedBy(1);
+
+        // Critical:
+        // The map generator may have already placed natural rock, ruins, plants,
+        // chunks, geysers, fogged mountain spaces, or other obstructions here.
+        // The facility footprint must be made clean before our generated structure
+        // is placed, otherwise doors can be sealed behind stone walls.
+        ClearFacilityFootprint(map, outerWallRect.ExpandedBy(2));
+
+        // Handle ocean and impassable tiles.
+        StargateDestinationMapGen.Apply(map, DescribeTile(map.Tile));
+
+        GenerateRoomStructure(map, roomRect, outerWallRect);
+        PlaceRoof(map, roomRect);
+        PlacePowerConduits(map, center, roomRect);
+        PlaceStargate(map, center);
+        PlaceSupportEquipment(map, center, roomRect);
+        PlaceDiningArea(map, roomRect, center);
+        AddFacilityDetails(map, roomRect, center);
+        ClaimHomeArea(map, roomRect);
+        SpawnColonists(map, center);
+
+        // Defer the fog override until RimWorld has finished its default passes.
+        LongEventHandler.ExecuteWhenFinished(() =>
+        {
+            // Force MapDrawer.sections allocation before anything touches FogGrid.
+            // FogGrid.Unfog -> MapDrawer.MapMeshDirty -> MapDrawer.SectionAt[null] NPEs
+            // when called this early. The base game guards on ProgramState.Playing,
+            // but RocketMan's UnfogWorker patch bypasses that guard. RegenerateEverythingNow
+            // is the cheapest public API that lazily allocates the sections grid.
+            map.mapDrawer.RegenerateEverythingNow();
+
+            // Step 1: re-fog the entire map.
+#if RIMWORLD15 || RIMWORLD16
+            map.fogGrid.Refog(new CellRect(0, 0, map.Size.x, map.Size.z));
+#else
+            bool[] fog = map.fogGrid.fogGrid;
+            for (int i = 0; i < fog.Length; i++) fog[i] = true;
+#endif
+
+            // Step 2: flood-unfog from inside the room. Same mechanism RimWorld uses
+            // when colonists mine through a wall and discover the cavity behind it.
+            IntVec3 unfogRoot = FindWalkableSeedCell(map, roomRect, center);
+            if (unfogRoot.IsValid)
+            {
+                FloodFillerFog.FloodUnfog(unfogRoot, map);
+            }
+            else
+            {
+                Log.Warning("BetterRimworlds.Stargate: No walkable seed cell found for fog flood-fill.");
+            }
+
+            // Step 3: final redraw to flush any deferred dirty flags.
+#if RIMWORLD15 || RIMWORLD16
+            map.mapDrawer.WholeMapChanged(MapMeshFlagDefOf.FogOfWar);
+            map.mapDrawer.WholeMapChanged(MapMeshFlagDefOf.Things);
+#else
+            map.mapDrawer.WholeMapChanged(MapMeshFlag.FogOfWar);
+            map.mapDrawer.WholeMapChanged(MapMeshFlag.Things);
+#endif
+
+            // Step 4: Show the Scenario Message Box after the map is fully loaded
+            // and the Stargate facility exists, but before the Stargate recall.
+            //
+            // CRITICAL:
+            // This message used to happen during Page_SelectStartingSite.PreOpen,
+            // which is too early. At that point the map does not exist yet.
+            //
+            // The intended timing is:
+            //   map generated
+            //   facility built
+            //   fog/home/equipment finalized
+            //   message shown
+            //   player clicks OK
+            //   StargateRecall fires
+            ShowScenarioMessage(map);
+        });
+    }
+
+    private void ShowScenarioMessage(Map map)
+    {
+        string msg = BuildScenarioMessage(map);
+
+        Find.WindowStack.Add(new Dialog_MessageBox(
+            msg,
+            "OK",
+            () =>
+            {
+                // TriggerStargateRecall(map);
+            }
+        ));
+    }
+
+    private string BuildScenarioMessage(Map map)
+    {
+        int selectedTile = map.Tile;
+        var tileInfo = map.TileInfo;
+        if (tileInfo.WaterCovered)
+        {
+        }
+
+        var c = StargateAutomationPatches.LastPlanetConditions;
+
+        return
+            "DAILY STARGATE PLANET CONDITIONS\n\n" +
+            "This is today's shared pseudo-multiplayer planet. All players on the same " +
+            "UTC date receive the same planet and planet-level conditions.\n\n" +
+            "Seed:        " + (c != null ? c.SeedString : "N/A") + "\n" +
+            "Coverage:    " + (c != null ? c.PlanetCoverage.ToString() : "N/A") + "\n" +
+            "Rainfall:    " + (c != null ? c.Rainfall.ToString() : "N/A") + "\n" +
+            "Temperature: " + (c != null ? c.Temperature.ToString() : "N/A") + "\n" +
+            "Population:  " + (c != null ? c.Population.ToString() : "N/A") + "\n\n" +
+            "===========================================\n\n" +
+            "RANDOM STARGATE DESTINATION SELECTED\n\n" +
+            "Daily planet seed:  " + StargateSeedUtility.GetDailySeed() + "\n" +
+            "Selected tile:      " + selectedTile + "\n" +
+            "Tile kind:          " + DescribeTile(selectedTile) + "\n\n" +
+            "Same planet. Different Stargate.\n" +
+            "Ocean → Atlantis  |  Impassable → Tok'ra  |  Normal → Surface facility";
+    }
+
+    // Locates the Stargate building instance on the provided map and triggers its recall sequence.
+    private void TriggerStargateRecall(Map map)
+    {
+        ThingDef stargateDef = ThingDef.Named("Stargate");
+
+        Thing spawnedGate = map.listerThings.ThingsOfDef(stargateDef).FirstOrDefault();
+
+        if (spawnedGate is Building_Stargate stargate)
+        {
+            stargate.StargateRecall();
+        }
+        else if (spawnedGate != null)
+        {
+            Log.Warning("BetterRimworlds.Stargate: Found a Stargate Thing, but could not cast it to the 'Stargate' class.");
+        }
+        else
+        {
+            Log.Warning("BetterRimworlds.Stargate: Stargate ThingDef exists, but no Stargate was found on the map to trigger recall.");
+        }
+    }
+
+    // Finds a walkable cell inside the room to seed FloodFillerFog.FloodUnfog.
+    // The room center is occupied by the impassable Stargate, so we pick a cell
+    // adjacent to it and fall back to a spiral search if that's blocked.
+    private IntVec3 FindWalkableSeedCell(Map map, CellRect roomRect, IntVec3 center)
+    {
+        // Primary candidate: 2 cells north of center (just past the stargate's footprint).
+        IntVec3 candidate = new IntVec3(center.x, 0, center.z + 2);
+        if (candidate.InBounds(map) && candidate.Walkable(map) && roomRect.Contains(candidate))
+        {
+            return candidate;
+        }
+
+        // Fallback: spiral outward from center, take the first walkable cell in the room.
+        foreach (IntVec3 cell in GenRadial.RadialCellsAround(center, RoomSize, true))
+        {
+            if (!cell.InBounds(map)) continue;
+            if (!roomRect.Contains(cell)) continue;
+            if (!cell.Walkable(map)) continue;
+
+            return cell;
+        }
+
+        return IntVec3.Invalid;
+    }
+}

--- a/Source/Scenario/StargateAutomationPatches.cs
+++ b/Source/Scenario/StargateAutomationPatches.cs
@@ -1,0 +1,375 @@
+// ==== Source/Scenario/StargateAutomationPatches.cs ====
+using System;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+[StaticConstructorOnStartup]
+public static class StargateAutomationPatches
+{
+    internal static StargateDailyPlanetConditions LastPlanetConditions;
+
+    static StargateAutomationPatches()
+    {
+        var harmony = new Harmony("com.betterrimworlds.stargate.automation");
+        harmony.PatchAll();
+        Log.Message("BetterRimworlds.Stargate: Harmony automation patches applied.");
+    }
+
+    // CRITICAL:
+    // Skipping Page_SelectStartingSite means we also skip vanilla side effects.
+    //
+    // Setting Find.GameInitData.startingTile is not enough. RimWorld expects a player
+    // faction base / settlement world object to exist before the starting map is
+    // generated. Without it, PageUtility.InitGameStart can fail with:
+    //
+    //   "Could not generate starting map because there is no any player faction base."
+    //
+    // This recreates the required vanilla state for the automated Stargate start.
+    internal static void EnsurePlayerFactionBaseAtStartingTile()
+    {
+        if (!StargateScenarioUtility.IsStargateBaseScenario())
+        {
+            return;
+        }
+
+        if (Find.GameInitData == null)
+        {
+            Log.Error("BetterRimworlds.Stargate: Cannot ensure player faction base because GameInitData is null.");
+            return;
+        }
+
+        int tile = Find.GameInitData.startingTile;
+        if (tile < 0)
+        {
+            Log.Error("BetterRimworlds.Stargate: Cannot ensure player faction base because startingTile is invalid: " + tile);
+            return;
+        }
+
+        if (Find.WorldObjects == null)
+        {
+            Log.Error("BetterRimworlds.Stargate: Cannot ensure player faction base because Find.WorldObjects is null.");
+            return;
+        }
+
+        // Avoid creating duplicates if vanilla, another mod, or a future refactor has
+        // already created the player settlement.
+        var worldObjects = Find.WorldObjects.AllWorldObjects;
+        for (int i = 0; i < worldObjects.Count; i++)
+        {
+            WorldObject worldObject = worldObjects[i];
+
+            if (worldObject == null)
+            {
+                continue;
+            }
+
+            if (worldObject.Faction == Faction.OfPlayer && worldObject is Settlement)
+            {
+                if (worldObject.Tile != tile)
+                {
+                    worldObject.Tile = tile;
+                }
+
+                return;
+            }
+        }
+
+        Settlement settlement = (Settlement)WorldObjectMaker.MakeWorldObject(WorldObjectDefOf.Settlement);
+        settlement.Tile = tile;
+        settlement.SetFaction(Faction.OfPlayer);
+
+        Find.WorldObjects.Add(settlement);
+
+        Log.Message("BetterRimworlds.Stargate: Created player faction base at Stargate destination tile " + tile + ".");
+    }
+}
+
+// 1. Auto-configure world parameters and click Next automatically.
+//
+// This is where the daily pseudo-multiplayer planet is created.
+//
+// Important:
+//   - The daily seed controls the planet.
+//   - The daily seed controls planet-level conditions.
+//   - The daily seed does NOT control the Stargate starting tile.
+//
+// In other words:
+//
+//   Same UTC day  => same planet.
+//   New game      => random Stargate destination on that planet.
+[HarmonyPatch(typeof(Page_CreateWorldParams), "PostOpen")]
+public static class Patch_Page_CreateWorldParams_PostOpen
+{
+    public static void Postfix(Page_CreateWorldParams __instance)
+    {
+        if (!StargateScenarioUtility.IsStargateBaseScenario())
+        {
+            return;
+        }
+
+        StargateDailyPlanetConditions conditions = StargateDailyPlanetConditions.Generate();
+
+        SetPrivateField(__instance, "seedString", conditions.SeedString);
+        SetPrivateField(__instance, "planetCoverage", conditions.PlanetCoverage);
+        SetPrivateField(__instance, "rainfall", conditions.Rainfall);
+        SetPrivateField(__instance, "temperature", conditions.Temperature);
+        SetPrivateField(__instance, "population", conditions.Population);
+
+        StargateAutomationPatches.LastPlanetConditions = conditions;
+
+        MethodInfo canDoNext = AccessTools.Method(typeof(Page_CreateWorldParams), "CanDoNext");
+        MethodInfo doNext = AccessTools.Method(typeof(Page_CreateWorldParams), "DoNext");
+
+        if (canDoNext == null || doNext == null)
+        {
+            Log.Error("BetterRimworlds.Stargate: Could not find Page_CreateWorldParams.CanDoNext or DoNext.");
+            return;
+        }
+
+        if ((bool)canDoNext.Invoke(__instance, null))
+        {
+            doNext.Invoke(__instance, null);
+        }
+    }
+
+    private static void SetPrivateField<T>(Page_CreateWorldParams page, string fieldName, T value)
+    {
+        FieldInfo field = AccessTools.Field(typeof(Page_CreateWorldParams), fieldName);
+
+        if (field == null)
+        {
+            Log.Error("BetterRimworlds.Stargate: Could not find Page_CreateWorldParams." + fieldName + ".");
+            return;
+        }
+
+        field.SetValue(page, value);
+    }
+}
+
+// 2. Skip the site selection screen entirely.
+//
+// Important:
+// The planet is deterministic.
+// The Stargate destination is intentionally NOT deterministic.
+//
+// That means:
+//   - Same UTC date = same planet.
+//   - Each new game = random Stargate destination on that planet.
+//
+// Ocean and impassable tiles are valid because this scenario has special gameplay:
+//   - Ocean       => Atlantis-style underwater base.
+//   - Impassable  => Tok'ra-style mountain base.
+//
+// CRITICAL:
+// Do NOT show the Scenario Message Box here.
+//
+// This page happens before the map exists. The scenario message is an in-game intro
+// beat and must happen after the map, Stargate facility, fog, equipment, and home area
+// are fully generated, but before StargateRecall().
+[HarmonyPatch(typeof(Page_SelectStartingSite), "PreOpen")]
+public static class Patch_Page_SelectStartingSite_PreOpen
+{
+    public static bool Prefix(Page_SelectStartingSite __instance)
+    {
+        if (!StargateScenarioUtility.IsStargateBaseScenario())
+        {
+            return true;
+        }
+
+        int selectedTile = SelectRandomStargateDestinationTile();
+        selectedTile = 114297;
+
+        Find.GameInitData.startingTile = selectedTile;
+
+        __instance.Close(false);
+
+        Find.WindowStack.Add(new Page_ConfigureStartingPawns());
+
+        return false;
+    }
+
+    private static int SelectRandomStargateDestinationTile()
+    {
+        int tilesCount = Find.WorldGrid.TilesCount;
+
+        if (tilesCount <= 0)
+        {
+            Log.Error("BetterRimworlds.Stargate: WorldGrid has no tiles. Falling back to tile 0.");
+            return 0;
+        }
+
+        // This is intentionally normal RNG, not daily-seeded RNG.
+        //
+        // DO NOT wrap this in StargateSeedUtility.WithDailySubSeed(...).
+        // DO NOT wrap this in Rand.PushState(dailySeed).
+        //
+        // The whole point is:
+        //   same daily planet,
+        //   random Stargate destination.
+        for (int attempt = 0; attempt < 1000; attempt++)
+        {
+            int tileId = Rand.Range(0, tilesCount);
+
+            if (TileExists(tileId))
+            {
+                return tileId;
+            }
+        }
+
+        // Extremely defensive fallback.
+        for (int tileId = 0; tileId < tilesCount; tileId++)
+        {
+            if (TileExists(tileId))
+            {
+                return tileId;
+            }
+        }
+
+        Log.Error("BetterRimworlds.Stargate: Could not find any usable world tile. Falling back to tile 0.");
+        return 0;
+    }
+
+    private static bool TileExists(int tileId)
+    {
+        if (tileId < 0 || tileId >= Find.WorldGrid.TilesCount)
+        {
+            return false;
+        }
+
+        Tile tile = GetTile(tileId);
+        return tile != null;
+    }
+
+    private static Tile GetTile(int tileId)
+    {
+#if RIMWORLD16
+        return Find.WorldGrid[tileId];
+#else
+        return Find.WorldGrid.tiles[tileId];
+#endif
+    }
+}
+
+// 3. Skip colonist selection and start game immediately.
+[HarmonyPatch(typeof(Page_ConfigureStartingPawns), "PostOpen")]
+public static class Patch_Page_ConfigureStartingPawns_PostOpen
+{
+    public static void Postfix(Page_ConfigureStartingPawns __instance)
+    {
+        if (!StargateScenarioUtility.IsStargateBaseScenario())
+        {
+            return;
+        }
+
+        // CRITICAL:
+        // Do not clear startingAndOptionalPawns here.
+        //
+        // The Stargate facility ScenPart uses the generated pawn list during map
+        // generation. The first pawn is placed into the Guardian's casket.
+        //
+        // Clearing this list here makes the scenario part unable to place the Guardian.
+
+        // CRITICAL:
+        // Because this automation bypasses vanilla Page_SelectStartingSite.DoNext, we
+        // must recreate the player faction base world object before InitGameStart().
+        StargateAutomationPatches.EnsurePlayerFactionBaseAtStartingTile();
+
+        PageUtility.InitGameStart();
+    }
+}
+
+internal sealed class StargateDailyPlanetConditions
+{
+    internal static StargateDailyPlanetConditions Generate()
+    {
+        string seedString = StargateSeedUtility.GetDailySeed();
+
+        float planetCoverage = StargateSeedUtility.WithDailySubSeed(
+            "planet-coverage",
+            () =>
+            {
+                float[] coverages = { 0.3f, 0.5f, 1.0f };
+                return coverages[Rand.Range(0, coverages.Length)];
+            }
+        );
+
+        OverallRainfall rainfall = StargateSeedUtility.WithDailySubSeed(
+            "overall-rainfall",
+            RandomEnumValue<OverallRainfall>
+        );
+
+        OverallTemperature temperature = StargateSeedUtility.WithDailySubSeed(
+            "overall-temperature",
+            RandomEnumValue<OverallTemperature>
+        );
+
+        OverallPopulation population = StargateSeedUtility.WithDailySubSeed(
+            "overall-population",
+            LoreWeightedPopulation
+        );
+
+        return new StargateDailyPlanetConditions(
+            seedString,
+            planetCoverage,
+            rainfall,
+            temperature,
+            population
+        );
+    }
+
+    private static T RandomEnumValue<T>()
+    {
+        Array values = Enum.GetValues(typeof(T));
+        return (T)values.GetValue(Rand.Range(0, values.Length));
+    }
+
+    private StargateDailyPlanetConditions(
+        string seedString,
+        float planetCoverage,
+        OverallRainfall rainfall,
+        OverallTemperature temperature,
+        OverallPopulation population
+    )
+    {
+        SeedString = seedString;
+        PlanetCoverage = planetCoverage;
+        Rainfall = rainfall;
+        Temperature = temperature;
+        Population = population;
+    }
+
+    internal string SeedString { get; }
+
+    internal float PlanetCoverage { get; }
+
+    internal OverallRainfall Rainfall { get; }
+
+    internal OverallTemperature Temperature { get; }
+
+    internal OverallPopulation Population { get; }
+    
+    private static OverallPopulation LoreWeightedPopulation()
+    {
+        float roll = Rand.Value;
+
+        if (roll < 0.20f) return OverallPopulation.AlmostNone;     // Abandoned ruins, tiny outpost
+        if (roll < 0.45f) return OverallPopulation.Little;         // Primitive villages, mining camps
+        if (roll < 0.65f) return OverallPopulation.LittleBitLess;  // Sparse subject world, frontier colony
+        if (roll < 0.80f) return OverallPopulation.Normal;         // Modest Goa'uld subject world
+        if (roll < 0.90f) return OverallPopulation.LittleBitMore;  // Established civilization
+        if (roll < 0.97f) return OverallPopulation.High;           // Significant population center
+        return                   OverallPopulation.VeryHigh;       // Exceptional — Langara-tier
+    }}
+
+internal static class StargateScenarioUtility
+{
+    internal static bool IsStargateBaseScenario()
+    {
+        return Find.Scenario != null && Find.Scenario.name == "Stargate Base";
+    }
+}

--- a/Source/Scenario/StargateDestinationMapGen.Cavern.cs
+++ b/Source/Scenario/StargateDestinationMapGen.Cavern.cs
@@ -1,0 +1,264 @@
+// ==== Source/Scenario/StargateDestinationMapGen.Cavern.cs ====
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+public static partial class StargateDestinationMapGen
+{
+    private static void GenerateImpassableSurroundings(Map map)
+    {
+        IntVec3 center = map.Center;
+        int halfSize  = RoomSize / 2;
+
+        // Preserve room + outer wall + one approach cell on each side.
+        CellRect preserveRect = new CellRect(
+            center.x - halfSize - 2,
+            center.z - halfSize - 2,
+            RoomSize + 4,
+            RoomSize + 4
+        );
+
+        // One dominant rock type per map matches how vanilla impassable maps look.
+        string[] rockTypes = {
+            "Granite", "Limestone", "Sandstone", "Marble", "Slate"
+        };
+        ThingDef primaryRock   = DefDatabase<ThingDef>.GetNamedSilentFail(rockTypes[Rand.Range(0, rockTypes.Length)]);
+        ThingDef secondaryRock = DefDatabase<ThingDef>.GetNamedSilentFail(rockTypes[Rand.Range(0, rockTypes.Length)]);
+        if (primaryRock == null)
+        {
+            Log.Warning("BetterRimworlds.Stargate: No rock defs found, skipping mountain gen.");
+            return;
+        }
+
+        RoofDef     thickRoof      = RoofDefOf.RoofRockThick;
+        TerrainDef  underlayStone  = DefDatabase<TerrainDef>.GetNamedSilentFail("Gravel")
+                                     ?? TerrainDefOf.Soil;
+
+        int impassableCount = 0;
+        int notImpassableCount = 0;
+
+        // Phase 1: fill the map with solid rock + thick stone roof.
+        foreach (IntVec3 cell in map.AllCells)
+        {
+            if (preserveRect.Contains(cell)) continue;
+
+            List<Thing> things = map.thingGrid.ThingsListAt(cell).ToList();
+            foreach (Thing thing in things)
+            {
+                if (thing is Pawn) continue;
+                if (thing.def.destroyable) thing.Destroy();
+            }
+
+            map.terrainGrid.SetTerrain(cell, underlayStone);
+
+            ThingDef rockDef = Rand.Chance(0.85f) ? primaryRock : (secondaryRock ?? primaryRock);
+            Thing rockThing = ThingMaker.MakeThing(rockDef);
+            GenSpawn.Spawn(rockThing, cell, map, WipeMode.Vanish);
+
+            map.roofGrid.SetRoof(cell, thickRoof);
+
+            if (rockThing.def.passability != Traversability.Impassable)
+            {
+                Log.Error(
+                    $"BetterRimworlds.Stargate: Tile {cell} is NOT IMPASSABLE after spawning. " +
+                    $"Def: {rockThing.def.defName}, Passability: {rockThing.def.passability}"
+                );
+                notImpassableCount++;
+            }
+            else
+            {
+                impassableCount++;
+            }
+        }
+
+        Log.Message(
+            $"BetterRimworlds.Stargate: Phase 1 Impassable Check Summary - " +
+            $"Impassable: {impassableCount}, Not Impassable: {notImpassableCount}"
+        );
+
+        // Phase 2: carve a handful of small caverns. Small on purpose — you wanted
+        // no major open spaces. Each cavern is 6–14 cells.
+        int cavernCount = Rand.Range(5, 9);
+        List<IntVec3> cavernCells = new List<IntVec3>();
+        for (int i = 0; i < cavernCount; i++)
+        {
+            IntVec3 seed = CellFinder.RandomCell(map);
+            if (preserveRect.ExpandedBy(3).Contains(seed)) continue;
+
+            int budget = Rand.Range(6, 15);
+            CarveCavern(map, seed, budget, cavernCells);
+        }
+
+        // Phase 3: plant cavern flora in the carved cells.
+        PlantCavernFlora(map, cavernCells);
+
+        // Phase 4: re-scatter ore into the remaining rock.
+        ScatterRichOreDeposits(map);
+        
+        // Phase 5: guaranteed veins on the cavern walls themselves.
+        // Runs after the general scatter so it overrides plain rock that the
+        // scatter pass missed — every cavern reliably has something worth mining.
+        PlaceCavernWallVeins(map, cavernCells);
+    }
+
+    private static void CarveCavern(Map map, IntVec3 seed, int budget, List<IntVec3> outCells)
+    {
+        Queue<IntVec3> frontier = new Queue<IntVec3>();
+        HashSet<IntVec3> visited = new HashSet<IntVec3>();
+        frontier.Enqueue(seed);
+
+        while (frontier.Count > 0 && budget > 0)
+        {
+            IntVec3 cell = frontier.Dequeue();
+            if (!cell.InBounds(map)) continue;
+            if (visited.Contains(cell)) continue;
+            visited.Add(cell);
+
+            // Remove the rock at this cell.
+            Thing rock = map.thingGrid.ThingsListAt(cell)
+                .FirstOrDefault(t => t.def.building != null && t.def.building.isNaturalRock);
+            if (rock == null) continue;
+
+            rock.Destroy(DestroyMode.Vanish);
+
+            // Thin roof so the cavern reads as a small natural void, not deep mountain.
+            map.roofGrid.SetRoof(cell, RoofDefOf.RoofRockThin);
+            outCells.Add(cell);
+            budget--;
+
+            // Spread to neighbors with some randomness — produces organic shapes.
+            foreach (IntVec3 dir in GenAdj.CardinalDirections)
+            {
+                if (Rand.Chance(0.55f)) frontier.Enqueue(cell + dir);
+            }
+        }
+    }
+
+    private static void PlantCavernFlora(Map map, List<IntVec3> cavernCells)
+    {
+        // Glowstool is vanilla. Agarilux/Bryolux are Royalty (present in 1.2+).
+        ThingDef glowstool = DefDatabase<ThingDef>.GetNamedSilentFail("Plant_Glowstool");
+        ThingDef agarilux  = DefDatabase<ThingDef>.GetNamedSilentFail("Plant_Agarilux");
+        ThingDef bryolux   = DefDatabase<ThingDef>.GetNamedSilentFail("Plant_Bryolux");
+
+        List<ThingDef> palette = new List<ThingDef>();
+        if (glowstool != null) palette.Add(glowstool);
+        if (agarilux  != null) palette.Add(agarilux);
+        if (bryolux   != null) palette.Add(bryolux);
+
+        if (palette.Count == 0) return;
+
+        TerrainDef cavernFloor = DefDatabase<TerrainDef>.GetNamedSilentFail("Gravel")
+                                 ?? TerrainDefOf.Soil;
+
+        foreach (IntVec3 cell in cavernCells)
+        {
+            if (!cell.InBounds(map)) continue;
+            if (!cell.Walkable(map)) continue;
+
+            // Mushrooms need a growable terrain. Gravel works in vanilla 1.2.
+            map.terrainGrid.SetTerrain(cell, cavernFloor);
+
+            if (!Rand.Chance(0.65f)) continue; // ~65% density — clusters, not carpet
+
+            ThingDef plantDef = palette.RandomElement();
+            Plant plant = (Plant)ThingMaker.MakeThing(plantDef);
+            plant.Growth = Rand.Range(0.45f, 1.0f);
+            GenSpawn.Spawn(plant, cell, map, WipeMode.Vanish);
+        }
+    }
+    
+    private static void ScatterRichOreDeposits(Map map)
+    {
+        // countPer10kCells is roughly 2-4x vanilla density.
+        // Vanilla steel is ~10, gold ~2-3.
+        ScatterOre(map, "MineableSteel",      25);
+        ScatterOre(map, "MineableSilver",     16);
+        ScatterOre(map, "MineableGold",       10);
+        ScatterOre(map, "MineableUranium",     8);
+        ScatterOre(map, "MineablePlasteel",    6);
+        ScatterOre(map, "MineableJade",        4);
+        ScatterOre(map, "MineableComponentIndustrialScattered", 5);
+    }
+
+    private static void ScatterOre(Map map, string defName, int countPer10kCells)
+    {
+        ThingDef oreDef = DefDatabase<ThingDef>.GetNamedSilentFail(defName);
+        if (oreDef == null)
+        {
+            Log.Warning($"BetterRimworlds.Stargate: Ore def '{defName}' not found, skipping.");
+            return;
+        }
+
+        var scatter = new GenStep_ScatterLumpsMineable();
+        scatter.forcedDefToScatter   = oreDef;
+        scatter.countPer10kCellsRange = new FloatRange(countPer10kCells, countPer10kCells);
+        scatter.Generate(map, new GenStepParams());
+    }
+    
+    private static void PlaceCavernWallVeins(Map map, List<IntVec3> cavernCells)
+    {
+        // Weighted palette: common metals more likely, rare materials sparse.
+        // These are the veins that reward carving into the cavern walls;
+        // ScatterRichOreDeposits already handled the bulk-rock distribution.
+        var oreOptions = new (string defName, float weight)[]
+        {
+            ("MineableSteel",                          3.0f),
+            ("MineableSilver",                         2.0f),
+            ("MineableGold",                           1.0f),
+            ("MineablePlasteel",                       1.0f),
+            ("MineableUranium",                        1.0f),
+            ("MineableJade",                           0.8f),
+            ("MineableComponentIndustrialScattered",   0.6f),
+        };
+
+        var palette = new List<(ThingDef def, float weight)>();
+        foreach (var (name, weight) in oreOptions)
+        {
+            ThingDef d = DefDatabase<ThingDef>.GetNamedSilentFail(name);
+            if (d != null) palette.Add((d, weight));
+        }
+        if (palette.Count == 0) return;
+
+        float totalWeight = 0f;
+        foreach (var entry in palette) totalWeight += entry.weight;
+
+        // Walk every cavern cell, find rock walls touching it, swap a fraction.
+        // ~25% conversion rate: dense enough to feel like a deliberate vein system,
+        // sparse enough that the caverns don't read as ore galleries.
+        HashSet<IntVec3> processed = new HashSet<IntVec3>();
+        foreach (IntVec3 cavernCell in cavernCells)
+        {
+            foreach (IntVec3 dir in GenAdj.CardinalDirections)
+            {
+                IntVec3 wall = cavernCell + dir;
+                if (!wall.InBounds(map)) continue;
+                if (!processed.Add(wall)) continue;
+
+                Thing rock = map.thingGrid.ThingsListAt(wall)
+                    .FirstOrDefault(t => t.def.building != null && t.def.building.isNaturalRock);
+                if (rock == null) continue;
+
+                if (!Rand.Chance(0.25f)) continue;
+
+                ThingDef oreDef = WeightedPickOre(palette, totalWeight);
+                rock.Destroy(DestroyMode.Vanish);
+                GenSpawn.Spawn(ThingMaker.MakeThing(oreDef), wall, map, WipeMode.Vanish);
+            }
+        }
+    }
+
+    private static ThingDef WeightedPickOre(List<(ThingDef def, float weight)> palette, float totalWeight)
+    {
+        float roll = Rand.Range(0f, totalWeight);
+        float acc  = 0f;
+        foreach (var (def, weight) in palette)
+        {
+            acc += weight;
+            if (roll <= acc) return def;
+        }
+        return palette[palette.Count - 1].def;
+    }
+}

--- a/Source/Scenario/StargateDestinationMapGen.Ocean.cs
+++ b/Source/Scenario/StargateDestinationMapGen.Ocean.cs
@@ -1,0 +1,56 @@
+// ==== Source/Scenario/StargateDestinationMapGen.Ocean.cs ====
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+public static partial class StargateDestinationMapGen
+{
+    private static void GenerateOceanSurroundings(Map map)
+    {
+        IntVec3 center = map.Center;
+        int halfSize   = RoomSize / 2;
+
+        CellRect facilityRect = new CellRect(
+            center.x - halfSize,
+            center.z - halfSize,
+            RoomSize,
+            RoomSize
+        );
+
+        // Shallow water apron: 2–10 tiles beyond the facility wall edge.
+        // The outerWallRect adds 1, so the real wall edge is halfSize + 1.
+        float wallEdge     = halfSize + 1f;
+        float shallowEdge  = wallEdge + Rand.Range(2, 11);
+
+        foreach (IntVec3 cell in map.AllCells)
+        {
+            // Skip facility interior — GenerateRoomStructure owns that terrain.
+            if (facilityRect.Contains(cell)) continue;
+
+            // Clear anything sitting in what will become water
+            // (rocks, plants, chunks — not pawns).
+            List<Thing> things = map.thingGrid.ThingsListAt(cell).ToList();
+            foreach (Thing thing in things)
+            {
+                if (thing is Pawn) continue;
+                if (thing.def.destroyable)
+                {
+                    thing.Destroy();
+                }
+            }
+
+            float dist = cell.DistanceTo(center);
+
+            if (dist <= shallowEdge)
+            {
+                map.terrainGrid.SetTerrain(cell, TerrainDefOf.WaterShallow);
+            }
+            else
+            {
+                map.terrainGrid.SetTerrain(cell, TerrainDefOf.WaterDeep);
+            }
+        }
+    }
+}

--- a/Source/Scenario/StargateDestinationMapGen.cs
+++ b/Source/Scenario/StargateDestinationMapGen.cs
@@ -1,0 +1,64 @@
+// ==== Source/Scenario/StargateDestinationMapGen.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+public static partial class StargateDestinationMapGen
+{
+   // Must match ScenPart_StargateFacility constants exactly.
+   private const int RoomSize = 15;
+
+   public static void Apply(Map map, string tileDescription)
+   {
+       // Always lay rich soil under the inner room footprint.
+       //
+       // Ocean:      removing concrete floors reveals farmable soil — Atlantis gardens.
+       // Impassable: underground growing under artificial light.
+       //
+       // This must run BEFORE GenerateRoomStructure, because SetTerrain stores the
+       // current terrain as underterrain when a floor type is placed on top.
+       // The sequence is:  SetTerrain(SoilRich) → SetTerrain(Concrete)
+       // Removing the concrete later restores the SoilRich underterrain.
+       SetFacilityUnderlayTerrain(map);
+
+       switch (tileDescription)
+       {
+           case "Ocean":
+               GenerateOceanSurroundings(map);
+               break;
+
+           case "Impassable":
+               GenerateImpassableSurroundings(map);
+               break;
+       }
+   }
+
+   // -------------------------------------------------------------------------
+
+   private static void SetFacilityUnderlayTerrain(Map map)
+   {
+       IntVec3 center = map.Center;
+       int halfSize   = RoomSize / 2;
+
+       CellRect roomRect = new CellRect(
+           center.x - halfSize,
+           center.z - halfSize,
+           RoomSize,
+           RoomSize
+       );
+
+       TerrainDef richSoil;
+       #if RIMWORLD12
+       richSoil = DefDatabase<TerrainDef>.GetNamed("SoilRich");
+       #else
+       richSoil = TerrainDefOf.SoilRich;
+       #endif
+
+       foreach (IntVec3 cell in roomRect.Cells)
+       {
+           if (!cell.InBounds(map)) continue;
+           map.terrainGrid.SetTerrain(cell, richSoil);
+       }
+   }
+}

--- a/Source/Scenario/StargateSeedUtility.cs
+++ b/Source/Scenario/StargateSeedUtility.cs
@@ -1,0 +1,158 @@
+// ==== Source/Scenario/StargateSeedUtility.cs ====
+using System;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+/// Centralized seed helper for the Stargate Base scenario.
+///
+/// This class exists because the scenario has two very different kinds of randomness:
+///
+///   1. DAILY PLANET DETERMINISM
+///      Every RimWorld player who starts the Stargate Base scenario on the same UTC date
+///      should receive the same base planet.
+///
+///      Example:
+///          2026-05-13
+///
+///      That date string becomes the shared daily planet seed. Planet-level settings
+///      like rainfall, temperature, population, and planet coverage should be derived
+///      from that date so the "daily planet" is reproducible worldwide.
+///
+///   2. LOCAL STARGATE DESTINATION RANDOMNESS
+///      The actual starting tile should NOT be derived from the daily seed.
+///
+///      The planet is shared.
+///      The Stargate address is random.
+///
+///      That means two players starting on the same UTC day can get the same planet,
+///      but different destinations:
+///
+///          Player A: ocean tile       -> Atlantis-style underwater base
+///          Player B: impassable tile  -> Tok'ra-style mountain base
+///          Player C: normal tile      -> surface Stargate facility
+///
+/// This utility is only for the deterministic daily planet layer.
+/// Do not use this class to pick the starting tile unless you intentionally want every
+/// player to get the exact same destination tile for that UTC day.
+internal static class StargateSeedUtility
+{
+    /// Returns the shared daily planet seed.
+    ///
+    /// This uses UTC, not local time, because players may be in different time zones.
+    /// The same UTC date should mean the same daily planet for everyone worldwide.
+    ///
+    /// Example return value:
+    ///     "2026-05-13"
+    ///
+    /// This string is suitable for RimWorld's world seed field.
+    internal static string GetDailySeed()
+    {
+        return DateTime.UtcNow.ToString("yyyy-MM-dd");
+    }
+
+    /// Produces a deterministic sub-seed for one specific planet-generation purpose.
+    ///
+    /// Why sub-seeds exist:
+    ///
+    /// If we used the raw daily seed directly for every setting, then all settings would
+    /// share the same random stream. That makes the code fragile. Adding one new random
+    /// roll for rainfall could accidentally change temperature, population, or other
+    /// settings.
+    ///
+    /// Instead, each planetary setting gets its own named deterministic seed:
+    ///
+    ///     2026-05-13|planet-coverage
+    ///     2026-05-13|overall-rainfall
+    ///     2026-05-13|overall-temperature
+    ///     2026-05-13|overall-population
+    ///
+    /// This keeps each setting stable and independent.
+    internal static int GetDailySubSeed(string purpose)
+    {
+        return StableHash(GetDailySeed() + "|" + purpose);
+    }
+
+    /// Stable string hash for deterministic cross-player seeds.
+    ///
+    /// Important:
+    /// Do NOT use string.GetHashCode() for shared deterministic gameplay.
+    ///
+    /// In modern .NET runtimes, string.GetHashCode() is not guaranteed to be stable
+    /// across processes, platforms, framework versions, or runtime configurations.
+    /// RimWorld version differences and Mono/.NET differences can also make that a bad
+    /// foundation for "everyone gets the same planet" behavior.
+    ///
+    /// This method uses FNV-1a, a simple deterministic hash algorithm. Given the same
+    /// input string, it returns the same integer every time.
+    ///
+    /// We mask to 0x7fffffff so the result is non-negative and safe to pass into
+    /// Verse.Rand.PushState().
+    internal static int StableHash(string text)
+    {
+        unchecked
+        {
+            uint hash = 2166136261;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                hash ^= text[i];
+                hash *= 16777619;
+            }
+
+            return (int)(hash & 0x7fffffff);
+        }
+    }
+
+    /// Temporarily replaces RimWorld's current random state with a deterministic daily
+    /// sub-seed, runs the supplied function, then restores the previous random state.
+    ///
+    /// Use this when deriving a daily planet setting:
+    ///
+    ///     OverallRainfall rainfall = StargateSeedUtility.WithDailySubSeed(
+    ///         "overall-rainfall",
+    ///         () => RandomEnumValue&lt;OverallRainfall&gt;()
+    ///     );
+    ///
+    /// The try/finally is critical. If an exception happens while the deterministic
+    /// seed is active, Rand.PopState() still runs and RimWorld's global RNG stack is
+    /// restored correctly.
+    ///
+    /// Do NOT wrap TileFinder.RandomStartingTile() in this helper unless you want the
+    /// destination tile to become deterministic for the whole UTC day.
+    internal static T WithDailySubSeed<T>(string purpose, Func<T> action)
+    {
+        Rand.PushState(GetDailySubSeed(purpose));
+
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            Rand.PopState();
+        }
+    }
+
+    /// Void-returning version of WithDailySubSeed.
+    ///
+    /// This is useful when the deterministic daily operation mutates something directly
+    /// instead of returning a value.
+    ///
+    /// Same warning:
+    /// This is for shared daily planet generation only. Do not use it for the random
+    /// Stargate destination tile.
+    internal static void WithDailySubSeed(string purpose, Action action)
+    {
+        Rand.PushState(GetDailySubSeed(purpose));
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Rand.PopState();
+        }
+    }
+}


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Automate Stargate base setup with daily planet variety and tile-based destination themes**

### What Changed
- The Stargate base scenario now skips the usual setup steps and starts the game directly with a generated starting map
- The planet settings are shared for the same UTC day, while the final starting location is still chosen randomly
- Ocean tiles now create an Atlantis-style base, impassable mountain tiles create a Tok'ra-style cavern base, and other tiles keep a surface facility
- The facility now builds with a fixed room layout, power, lights, food, a guardian casket, and a claimed home area for the starting colonists
- The start flow now waits until the map is ready before showing the scenario message, avoiding the earlier timing issue

### Impact
`✅ Faster Stargate scenario start`
`✅ More varied base locations from the same daily planet`
`✅ Fewer broken starts on ocean or mountain tiles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
