### PR TITLE
Added a system to prevent airdrop incidents in Tok'ra bases

### DIFF
--- a/Source/Scenario/MapComponent_SealedFromSky.cs
+++ b/Source/Scenario/MapComponent_SealedFromSky.cs
@@ -1,0 +1,17 @@
+// ==== Source/Scenario/MapComponent_SealedFromSky.cs ====
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+public class MapComponent_SealedFromSky : MapComponent
+{
+    public bool isSealed = false;
+
+    public MapComponent_SealedFromSky(Map map) : base(map) { }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+        Scribe_Values.Look(ref isSealed, "isSealed", false);
+    }
+}

--- a/Source/Scenario/RequiresSkyAccess.cs
+++ b/Source/Scenario/RequiresSkyAccess.cs
@@ -1,0 +1,7 @@
+// ==== Source/Scenario/RequiresSkyAccess.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+public class RequiresSkyAccess : DefModExtension { }

--- a/Source/Scenario/SkyfallerPatches.cs
+++ b/Source/Scenario/SkyfallerPatches.cs
@@ -1,0 +1,80 @@
+// ==== Source/Scenario/SkyfallerPatches.cs ====
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.Stargate;
+
+[StaticConstructorOnStartup]
+public static class SkyfallerPatches
+{
+    private static readonly HashSet<string> SkyAccessIncidentDefNames = new()
+    {
+        "CargoPodCrash",
+        "RefugeePodCrash",   // Vanilla "Transport pod crash"
+        "ShipChunkDrop",
+    };
+
+    static SkyfallerPatches()
+    {
+        var harmony = new Harmony("betterrimworlds.stargate.skyfallers");
+
+        foreach (Type type in typeof(IncidentWorker).Assembly.GetTypes()
+                     .Where(t => typeof(IncidentWorker).IsAssignableFrom(t)))
+        {
+            PatchDeclaredMethod(harmony, type, nameof(IncidentWorker.CanFireNow), postfix: nameof(CanFireNow_Postfix));
+            PatchDeclaredMethod(harmony, type, nameof(IncidentWorker.TryExecute), prefix: nameof(TryExecute_Prefix));
+        }
+    }
+
+    private static void PatchDeclaredMethod(Harmony harmony, Type type, string methodName, string? prefix = null, string? postfix = null)
+    {
+        MethodInfo? method = type.GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly
+        );
+
+        if (method == null) return;
+
+        harmony.Patch(
+            method,
+            prefix: prefix == null ? null : new HarmonyMethod(typeof(SkyfallerPatches), prefix),
+            postfix: postfix == null ? null : new HarmonyMethod(typeof(SkyfallerPatches), postfix)
+        );
+    }
+
+    public static void CanFireNow_Postfix(IncidentWorker __instance, IncidentParms parms, ref bool __result)
+    {
+        if (!__result) return;
+        if (!ShouldBlockSkyIncident(__instance, parms)) return;
+
+        __result = false;
+    }
+
+    public static bool TryExecute_Prefix(IncidentWorker __instance, IncidentParms parms, ref bool __result)
+    {
+        if (!ShouldBlockSkyIncident(__instance, parms)) return true;
+
+        __result = false;
+        return false;
+    }
+
+    private static bool ShouldBlockSkyIncident(IncidentWorker worker, IncidentParms parms)
+    {
+        if (worker?.def == null) return false;
+        if (parms.target is not Map map) return false;
+
+        bool requiresSky =
+            worker.def.HasModExtension<RequiresSkyAccess>() ||
+            SkyAccessIncidentDefNames.Contains(worker.def.defName);
+
+        if (!requiresSky) return false;
+
+        var sealedComp = map.GetComponent<MapComponent_SealedFromSky>();
+        return sealedComp?.isSealed == true;
+    }
+}

--- a/Source/Scenario/StargateAutomationPatches.cs
+++ b/Source/Scenario/StargateAutomationPatches.cs
@@ -182,7 +182,8 @@ public static class Patch_Page_SelectStartingSite_PreOpen
         }
 
         int selectedTile = SelectRandomStargateDestinationTile();
-        selectedTile = 114297;
+        // Hardcode startTile
+        // selectedTile = 23175;
 
         Find.GameInitData.startingTile = selectedTile;
 
@@ -370,6 +371,6 @@ internal static class StargateScenarioUtility
 {
     internal static bool IsStargateBaseScenario()
     {
-        return Find.Scenario != null && Find.Scenario.name == "Stargate Base";
+        return Find.Scenario != null && Find.Scenario.name == "Daily Stargate Outpost";
     }
 }

--- a/Source/Scenario/StargateDestinationMapGen.Cavern.cs
+++ b/Source/Scenario/StargateDestinationMapGen.Cavern.cs
@@ -101,6 +101,9 @@ public static partial class StargateDestinationMapGen
         // Runs after the general scatter so it overrides plain rock that the
         // scatter pass missed — every cavern reliably has something worth mining.
         PlaceCavernWallVeins(map, cavernCells);
+
+        // Mark this map as sealed from the sky so airdrop incidents are blocked.
+        map.GetComponent<MapComponent_SealedFromSky>().isSealed = true;
     }
 
     private static void CarveCavern(Map map, IntVec3 seed, int budget, List<IntVec3> outCells)

--- a/Stargate/Defs/Scenario/StargateScenarioDef.xml
+++ b/Stargate/Defs/Scenario/StargateScenarioDef.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <ScenarioDef>
+        <defName>StargateBase</defName>
+        <label>Daily Stargate Outpost</label>
+        <description>You start in an ancient facility containing a functional Stargate...</description>
+        <scenario>
+            <summary>Start with a pre-built Stargate facility.</summary>
+            <playerFaction>
+                <def>PlayerFaction</def>
+                <factionDef>PlayerColony</factionDef>
+            </playerFaction>
+            <parts>
+                <!-- Config pages -->
+                <!--
+                <li Class="ScenPart_ConfigPage_ConfigureStartingPawns">
+                    <def>ConfigPage_ConfigureStartingPawns</def>
+                    <pawnCount>3</pawnCount>
+                    <pawnChoiceCount>8</pawnChoiceCount>
+                </li>
+                -->
+                <!-- The custom map generator part -->
+                <li Class="BetterRimworlds.Stargate.ScenPart_StargateFacility">
+                    <def>StargateFacility</def>
+                </li>
+                <li Class="ScenPart_StartingThing_Defined">
+                    <def>StartingThing_Defined</def>
+                    <thingDef>MealSurvivalPack</thingDef>
+                    <count>10</count>
+                </li>
+            </parts>
+        </scenario>
+    </ScenarioDef>
+    <ScenPartDef>
+        <defName>StargateFacility</defName>
+        <label>stargate facility</label>
+        <description>Generates a pre-built facility containing a Stargate at map center.</description>
+        <scenPartClass>BetterRimworlds.Stargate.ScenPart_StargateFacility</scenPartClass>
+        <category>MapGeneration</category>
+        <summaryPriority>500</summaryPriority>
+    </ScenPartDef>
+</Defs>

--- a/Stargate/Patches/SkyAccessPatches.xml
+++ b/Stargate/Patches/SkyAccessPatches.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- ==== Patches/SkyAccessPatches.xml ==== -->
+<Patch>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/IncidentDef[defName="CargoPodCrash"]</xpath>
+    <value>
+      <li Class="BetterRimworlds.Stargate.RequiresSkyAccess"/>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/IncidentDef[defName="RefugeePodCrash"]</xpath>
+    <value>
+      <li Class="BetterRimworlds.Stargate.RequiresSkyAccess"/>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/IncidentDef[defName="ShipChunkDrop"]</xpath>
+    <value>
+      <li Class="BetterRimworlds.Stargate.RequiresSkyAccess"/>
+    </value>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## **User description**
- Prevents incidents like cargo pod crashes from occurring on maps without sky access.
- Adds MapComponent_SealedFromSky to track if a map is enclosed.
- Adds RequiresSkyAccess DefModExtension and Harmony patches to block sky-requiring incidents on sealed maps.
- Automatically marks cavern maps as sealed during generation.
- Updates scenario starting tile and name to "Daily Stargate Outpost".


___

## **CodeAnt-AI Description**
**Block sky-based incidents in sealed maps and update the Stargate scenario name**

### What Changed
- Cargo pod crashes, transport pod crashes, and ship chunk drops are now blocked on maps that are sealed from the sky.
- Cavern maps are automatically marked as sealed, so airdrop-style incidents no longer fire there.
- The Stargate base scenario now appears as “Daily Stargate Outpost.”
- The starting site selection for the scenario now uses the updated destination flow.

### Impact
`✅ Fewer airdrop incidents in caverns`
`✅ Prevents sky-only crashes on enclosed maps`
`✅ Clearer Stargate scenario selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
